### PR TITLE
PoC: Changed rules to be async

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -279,12 +279,12 @@ function publishSite() {
  * and generates the site in an adjacent `website` folder.
  * @returns {void}
  */
-function generateRelease() {
+async function generateRelease() {
     ReleaseOps.generateRelease();
     const releaseInfo = JSON.parse(cat(".eslint-release-info.json"));
 
     echo("Generating site");
-    target.gensite();
+    await target.gensite();
     generateBlogPost(releaseInfo);
     commitSiteToGit(`v${releaseInfo.version}`);
 
@@ -306,7 +306,7 @@ function generateRelease() {
  * @param {string} prereleaseId The prerelease identifier (alpha, beta, etc.)
  * @returns {void}
  */
-function generatePrerelease(prereleaseId) {
+async function generatePrerelease(prereleaseId) {
     ReleaseOps.generateRelease(prereleaseId);
     const releaseInfo = JSON.parse(cat(".eslint-release-info.json"));
     const nextMajor = semver.inc(releaseInfo.version, "major");
@@ -314,7 +314,7 @@ function generatePrerelease(prereleaseId) {
     echo("Generating site");
 
     // always write docs into the next major directory (so 2.0.0-alpha.0 writes to 2.0.0)
-    target.gensite(nextMajor);
+    await target.gensite(nextMajor);
 
     /*
      * Premajor release should have identical "next major version".
@@ -454,7 +454,7 @@ function lintMarkdown(files) {
  * Gets linting results from every formatter, based on a hard-coded snippet and config
  * @returns {Object} Output from each formatter
  */
-function getFormatterResults() {
+async function getFormatterResults() {
     const stripAnsi = require("strip-ansi");
     const formattersMetadata = require("./lib/cli-engine/formatters/formatters-meta.json");
 
@@ -480,7 +480,7 @@ function getFormatterResults() {
             "    }",
             "};"
         ].join("\n"),
-        rawMessages = cli.executeOnText(codeString, "fullOfProblems.js", true),
+        rawMessages = await cli.executeOnText(codeString, "fullOfProblems.js", true),
         rulesMap = cli.getRules(),
         rulesMeta = {};
 
@@ -648,7 +648,7 @@ target.test = function() {
     target.checkLicenses();
 };
 
-target.gensite = function() {
+target.gensite = async function() {
     echo("Generating documentation");
 
     const DOCS_RULES_DIR = path.join(DOCS_SRC_DIR, "rules");
@@ -696,7 +696,7 @@ target.gensite = function() {
 
     // 3. Create Example Formatter Output Page
     echo("> Creating the formatter examples (Step 3)");
-    generateFormatterExamples(getFormatterResults());
+    generateFormatterExamples(await getFormatterResults());
 
     echo("Done generating documentation");
 };
@@ -1097,5 +1097,5 @@ target.perf = function() {
 };
 
 target.generateRelease = generateRelease;
-target.generatePrerelease = ([prereleaseType]) => generatePrerelease(prereleaseType);
+target.generatePrerelease = async ([prereleaseType]) => await generatePrerelease(prereleaseType);
 target.publishRelease = publishRelease;

--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -227,10 +227,10 @@ function calculateStatsPerRun(results) {
  * @param {boolean} config.reportUnusedDisableDirectives If `true` then it reports unused `eslint-disable` comments.
  * @param {FileEnumerator} config.fileEnumerator The file enumerator to check if a path is a target or not.
  * @param {Linter} config.linter The linter instance to verify.
- * @returns {LintResult} The result of linting.
+ * @returns {Promise<LintResult>} The result of linting.
  * @private
  */
-function verifyText({
+async function verifyText({
     text,
     cwd,
     filePath: providedFilePath,
@@ -251,7 +251,7 @@ function verifyText({
      * doesn't know CWD, so it gives `linter` an absolute path always.
      */
     const filePathToVerify = filePath === "<text>" ? path.join(cwd, filePath) : filePath;
-    const { fixed, messages, output } = linter.verifyAndFix(
+    const { fixed, messages, output } = await linter.verifyAndFix(
         text,
         config,
         {
@@ -758,7 +758,7 @@ class CLIEngine {
      * @throws {Error} As may be thrown by `fs.unlinkSync`.
      * @returns {LintReport} The results for all files that were linted.
      */
-    executeOnFiles(patterns) {
+    async executeOnFiles(patterns) {
         const {
             cacheFilePath,
             fileEnumerator,
@@ -831,7 +831,7 @@ class CLIEngine {
             }
 
             // Do lint.
-            const result = verifyText({
+            const result = await verifyText({
                 text: fs.readFileSync(filePath, "utf8"),
                 filePath,
                 config,
@@ -887,7 +887,7 @@ class CLIEngine {
      * @param {boolean} [warnIgnored] Always warn when a file is ignored
      * @returns {LintReport} The results for the linting.
      */
-    executeOnText(text, filename, warnIgnored) {
+    async executeOnText(text, filename, warnIgnored) {
         const {
             configArrayFactory,
             fileEnumerator,
@@ -925,7 +925,7 @@ class CLIEngine {
             lastConfigArrays.push(config);
 
             // Do lint.
-            results.push(verifyText({
+            results.push(await verifyText({
                 text,
                 filePath: resolvedFilename,
                 config,

--- a/lib/cli-engine/file-enumerator.js
+++ b/lib/cli-engine/file-enumerator.js
@@ -21,7 +21,7 @@
  *
  * for (const { config, filePath } of enumerator.iterateFiles(["*.js"])) {
  *     const code = fs.readFileSync(filePath, "utf8");
- *     const messages = linter.verify(code, config, filePath);
+ *     const messages = await linter.verify(code, config, filePath);
  *
  *     console.log(messages);
  * }

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -548,7 +548,7 @@ class ESLint {
 
         return processCLIEngineLintReport(
             cliEngine,
-            cliEngine.executeOnFiles(patterns)
+            await cliEngine.executeOnFiles(patterns)
         );
     }
 
@@ -590,7 +590,7 @@ class ESLint {
 
         return processCLIEngineLintReport(
             cliEngine,
-            cliEngine.executeOnText(code, filePath, warnIgnored)
+            await cliEngine.executeOnText(code, filePath, warnIgnored)
         );
     }
 

--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -271,11 +271,9 @@ async function loadFlatConfigFile(filePath) {
      * to import the current version of the config file. Without the query, `import()` would
      * cache the config file module by the pathname only, and then always return
      * the same version (the one that was actual when the module was imported for the first time).
-     *
      * This ensures that the config file module is loaded and executed again
      * if it has been changed since the last time it was imported.
      * If it hasn't been changed, `import()` will just return the cached version.
-     *
      * Note that we should not overuse queries (e.g., by appending the current time
      * to always reload the config file module) as that could cause memory leaks
      * because entries are never removed from the import cache.
@@ -452,7 +450,7 @@ async function calculateConfigArray(eslint, {
  * @returns {LintResult} The result of linting.
  * @private
  */
-function verifyText({
+async function verifyText({
     text,
     cwd,
     filePath: providedFilePath,
@@ -472,7 +470,7 @@ function verifyText({
      * doesn't know CWD, so it gives `linter` an absolute path always.
      */
     const filePathToVerify = filePath === "<text>" ? getPlaceholderPath(cwd) : filePath;
-    const { fixed, messages, output } = linter.verifyAndFix(
+    const { fixed, messages, output } = await linter.verifyAndFix(
         text,
         configs,
         {
@@ -842,10 +840,10 @@ class FlatESLint {
                 }
 
                 return fs.readFile(filePath, "utf8")
-                    .then(text => {
+                    .then(text =>
 
                         // do the linting
-                        const result = verifyText({
+                        verifyText({
                             text,
                             filePath,
                             configs,
@@ -854,7 +852,8 @@ class FlatESLint {
                             allowInlineConfig,
                             reportUnusedDisableDirectives,
                             linter
-                        });
+                        }))
+                    .then(result => {
 
                         /*
                          * Store the lint result in the LintResultCache.
@@ -951,7 +950,7 @@ class FlatESLint {
         } else {
 
             // Do lint.
-            results.push(verifyText({
+            results.push(await verifyText({
                 text: code,
                 filePath: resolvedFilename.endsWith("__placeholder__.js") ? "<text>" : resolvedFilename,
                 configs,

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -511,6 +511,17 @@ function getDirectiveComments(ast, ruleMapper, warnInlineConfig) {
     };
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc -- prototype
+async function mapAsync(values, mapper) {
+    const results = [];
+
+    for (let i = 0; i < values.length; i += 1) {
+        results.push(await mapper(values[i], i, values));
+    }
+
+    return results;
+}
+
 /**
  * Normalize ECMAScript version from the initial config
  * @param {Parser} parser The parser which uses this options.
@@ -865,9 +876,9 @@ function parse(text, languageOptions, filePath) {
  * @throws {any} Any error during the rule's `create`
  * @returns {Object} A map of selector listeners provided by the rule
  */
-function createRuleListeners(rule, ruleContext) {
+async function createRuleListeners(rule, ruleContext) {
     try {
-        return rule.create(ruleContext);
+        return await rule.create(ruleContext);
     } catch (ex) {
         ex.message = `Error while loading rule '${ruleContext.id}': ${ex.message}`;
         throw ex;
@@ -922,9 +933,9 @@ const BASE_TRAVERSAL_CONTEXT = Object.freeze(
  * @param {boolean} disableFixes If true, it doesn't make `fix` properties.
  * @param {string | undefined} cwd cwd of the cli
  * @param {string} physicalFilename The full path of the file on disk without any code block information
- * @returns {LintMessage[]} An array of reported problems
+ * @returns {Promise<LintMessage[]>} An array of reported problems
  */
-function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageOptions, settings, filename, disableFixes, cwd, physicalFilename) {
+async function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageOptions, settings, filename, disableFixes, cwd, physicalFilename) {
     const emitter = createEmitter();
     const nodeQueue = [];
     let currentNode = sourceCode.ast;
@@ -974,19 +985,19 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageO
 
     const lintingProblems = [];
 
-    Object.keys(configuredRules).forEach(ruleId => {
+    for (const ruleId of Object.keys(configuredRules)) {
         const severity = ConfigOps.getRuleSeverity(configuredRules[ruleId]);
 
         // not load disabled rules
         if (severity === 0) {
-            return;
+            continue;
         }
 
         const rule = ruleMapper(ruleId);
 
         if (!rule) {
             lintingProblems.push(createLintingProblem({ ruleId }));
-            return;
+            continue;
         }
 
         const messageIds = rule.meta && rule.meta.messages;
@@ -1037,13 +1048,14 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageO
             )
         );
 
-        const ruleListeners = timing.enabled ? timing.time(ruleId, createRuleListeners)(rule, ruleContext) : createRuleListeners(rule, ruleContext);
+        const ruleListeners = await (timing.enabled ? timing.time(ruleId, createRuleListeners)(rule, ruleContext) : createRuleListeners(rule, ruleContext));
 
         /**
          * Include `ruleId` in error logs
          * @param {Function} ruleListener A rule method that listens for a node.
          * @returns {Function} ruleListener wrapped in error handler
          */
+        // eslint-disable-next-line no-inner-declarations -- prototype
         function addRuleErrorHandler(ruleListener) {
             return function ruleErrorHandler(...listenerArgs) {
                 try {
@@ -1070,7 +1082,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageO
                 addRuleErrorHandler(ruleListener)
             );
         });
-    });
+    }
 
     // only run code path analyzer if the top level node is "Program", skip otherwise
     const eventGenerator = nodeQueue[0].node.type === "Program"
@@ -1222,9 +1234,9 @@ class Linter {
      * @param {ConfigData} providedConfig An ESLintConfig instance to configure everything.
      * @param {VerifyOptions} [providedOptions] The optional filename of the file being checked.
      * @throws {Error} If during rule execution.
-     * @returns {(LintMessage|SuppressedLintMessage)[]} The results as an array of messages or an empty array if no messages.
+     * @returns {Promise<(LintMessage|SuppressedLintMessage)[]>} The results as an array of messages or an empty array if no messages.
      */
-    _verifyWithoutProcessors(textOrSourceCode, providedConfig, providedOptions) {
+    async _verifyWithoutProcessors(textOrSourceCode, providedConfig, providedOptions) {
         const slots = internalSlotsMap.get(this);
         const config = providedConfig || {};
         const options = normalizeVerifyOptions(providedOptions, config);
@@ -1327,7 +1339,7 @@ class Linter {
         let lintingProblems;
 
         try {
-            lintingProblems = runRules(
+            lintingProblems = await runRules(
                 sourceCode,
                 configuredRules,
                 ruleId => getRule(slots, ruleId),
@@ -1377,9 +1389,9 @@ class Linter {
      * @param {(string|(VerifyOptions&ProcessorOptions))} [filenameOrOptions] The optional filename of the file being checked.
      *      If this is not set, the filename will default to '<input>' in the rule context. If
      *      an object, then it has "filename", "allowInlineConfig", and some properties.
-     * @returns {LintMessage[]} The results as an array of messages or an empty array if no messages.
+     * @returns {Promise<LintMessage[]>} The results as an array of messages or an empty array if no messages.
      */
-    verify(textOrSourceCode, config, filenameOrOptions) {
+    async verify(textOrSourceCode, config, filenameOrOptions) {
         debug("Verify");
 
         const { configType } = internalSlotsMap.get(this);
@@ -1405,11 +1417,11 @@ class Linter {
                     configArray.normalizeSync();
                 }
 
-                return this._distinguishSuppressedMessages(this._verifyWithFlatConfigArray(textOrSourceCode, configArray, options, true));
+                return this._distinguishSuppressedMessages(await this._verifyWithFlatConfigArray(textOrSourceCode, configArray, options, true));
             }
 
             if (typeof config.extractConfig === "function") {
-                return this._distinguishSuppressedMessages(this._verifyWithConfigArray(textOrSourceCode, config, options));
+                return this._distinguishSuppressedMessages(await this._verifyWithConfigArray(textOrSourceCode, config, options));
             }
         }
 
@@ -1423,9 +1435,9 @@ class Linter {
          * So we cannot apply multiple processors.
          */
         if (options.preprocess || options.postprocess) {
-            return this._distinguishSuppressedMessages(this._verifyWithProcessor(textOrSourceCode, config, options));
+            return this._distinguishSuppressedMessages(await this._verifyWithProcessor(textOrSourceCode, config, options));
         }
-        return this._distinguishSuppressedMessages(this._verifyWithoutProcessors(textOrSourceCode, config, options));
+        return this._distinguishSuppressedMessages(await this._verifyWithoutProcessors(textOrSourceCode, config, options));
     }
 
     /**
@@ -1434,9 +1446,9 @@ class Linter {
      * @param {FlatConfig} config The config array.
      * @param {VerifyOptions&ProcessorOptions} options The options.
      * @param {FlatConfigArray} [configForRecursive] The `ConfigArray` object to apply multiple processors recursively.
-     * @returns {(LintMessage|SuppressedLintMessage)[]} The found problems.
+     * @returns {Promise<(LintMessage|SuppressedLintMessage)[]>} The found problems.
      */
-    _verifyWithFlatConfigArrayAndProcessor(textOrSourceCode, config, options, configForRecursive) {
+    async _verifyWithFlatConfigArrayAndProcessor(textOrSourceCode, config, options, configForRecursive) {
         const filename = options.filename || "<input>";
         const filenameToExpose = normalizeFilename(filename);
         const physicalFilename = options.physicalFilename || filenameToExpose;
@@ -1472,12 +1484,12 @@ class Linter {
             ];
         }
 
-        const messageLists = blocks.map((block, i) => {
+        const messageLists = await mapAsync(blocks, async (block, i) => {
             debug("A code block was found: %o", block.filename || "(unnamed)");
 
             // Keep the legacy behavior.
             if (typeof block === "string") {
-                return this._verifyWithFlatConfigArrayAndWithoutProcessors(block, config, options);
+                return await this._verifyWithFlatConfigArrayAndWithoutProcessors(block, config, options);
             }
 
             const blockText = block.text;
@@ -1492,7 +1504,7 @@ class Linter {
             // Resolve configuration again if the file content or extension was changed.
             if (configForRecursive && (text !== blockText || path.extname(blockName) !== originalExtname)) {
                 debug("Resolving configuration again because the file content or extension was changed.");
-                return this._verifyWithFlatConfigArray(
+                return await this._verifyWithFlatConfigArray(
                     blockText,
                     configForRecursive,
                     { ...options, filename: blockName, physicalFilename }
@@ -1500,7 +1512,7 @@ class Linter {
             }
 
             // Does lint.
-            return this._verifyWithFlatConfigArrayAndWithoutProcessors(
+            return await this._verifyWithFlatConfigArrayAndWithoutProcessors(
                 blockText,
                 config,
                 { ...options, filename: blockName, physicalFilename }
@@ -1516,9 +1528,9 @@ class Linter {
      * @param {FlatConfig} providedConfig An ESLintConfig instance to configure everything.
      * @param {VerifyOptions} [providedOptions] The optional filename of the file being checked.
      * @throws {Error} If during rule execution.
-     * @returns {(LintMessage|SuppressedLintMessage)[]} The results as an array of messages or an empty array if no messages.
+     * @returns {Promise<(LintMessage|SuppressedLintMessage)[]>} The results as an array of messages or an empty array if no messages.
      */
-    _verifyWithFlatConfigArrayAndWithoutProcessors(textOrSourceCode, providedConfig, providedOptions) {
+    async _verifyWithFlatConfigArrayAndWithoutProcessors(textOrSourceCode, providedConfig, providedOptions) {
         const slots = internalSlotsMap.get(this);
         const config = providedConfig || {};
         const options = normalizeVerifyOptions(providedOptions, config);
@@ -1627,7 +1639,7 @@ class Linter {
         let lintingProblems;
 
         try {
-            lintingProblems = runRules(
+            lintingProblems = await runRules(
                 sourceCode,
                 configuredRules,
                 ruleId => getRuleFromConfig(ruleId, config),
@@ -1676,9 +1688,9 @@ class Linter {
      * @param {string|SourceCode} textOrSourceCode The source code.
      * @param {ConfigArray} configArray The config array.
      * @param {VerifyOptions&ProcessorOptions} options The options.
-     * @returns {(LintMessage|SuppressedLintMessage)[]} The found problems.
+     * @returns {Promise<(LintMessage|SuppressedLintMessage)[]>} The found problems.
      */
-    _verifyWithConfigArray(textOrSourceCode, configArray, options) {
+    async _verifyWithConfigArray(textOrSourceCode, configArray, options) {
         debug("With ConfigArray: %s", options.filename);
 
         // Store the config array in order to get plugin envs and rules later.
@@ -1696,14 +1708,14 @@ class Linter {
             const { preprocess, postprocess, supportsAutofix } = processor;
             const disableFixes = options.disableFixes || !supportsAutofix;
 
-            return this._verifyWithProcessor(
+            return await this._verifyWithProcessor(
                 textOrSourceCode,
                 config,
                 { ...options, disableFixes, postprocess, preprocess },
                 configArray
             );
         }
-        return this._verifyWithoutProcessors(textOrSourceCode, config, options);
+        return await this._verifyWithoutProcessors(textOrSourceCode, config, options);
     }
 
     /**
@@ -1713,9 +1725,9 @@ class Linter {
      * @param {VerifyOptions&ProcessorOptions} options The options.
      * @param {boolean} [firstCall=false] Indicates if this is being called directly
      *      from verify(). (TODO: Remove once eslintrc is removed.)
-     * @returns {(LintMessage|SuppressedLintMessage)[]} The found problems.
+     * @returns {Promise<(LintMessage|SuppressedLintMessage)[]>} The found problems.
      */
-    _verifyWithFlatConfigArray(textOrSourceCode, configArray, options, firstCall = false) {
+    async _verifyWithFlatConfigArray(textOrSourceCode, configArray, options, firstCall = false) {
         debug("With flat config: %s", options.filename);
 
         // we need a filename to match configs against
@@ -1744,7 +1756,7 @@ class Linter {
             const { preprocess, postprocess, supportsAutofix } = config.processor;
             const disableFixes = options.disableFixes || !supportsAutofix;
 
-            return this._verifyWithFlatConfigArrayAndProcessor(
+            return await this._verifyWithFlatConfigArrayAndProcessor(
                 textOrSourceCode,
                 config,
                 { ...options, filename, disableFixes, postprocess, preprocess },
@@ -1754,10 +1766,10 @@ class Linter {
 
         // check for options-based processing
         if (firstCall && (options.preprocess || options.postprocess)) {
-            return this._verifyWithFlatConfigArrayAndProcessor(textOrSourceCode, config, options);
+            return await this._verifyWithFlatConfigArrayAndProcessor(textOrSourceCode, config, options);
         }
 
-        return this._verifyWithFlatConfigArrayAndWithoutProcessors(textOrSourceCode, config, options);
+        return await this._verifyWithFlatConfigArrayAndWithoutProcessors(textOrSourceCode, config, options);
     }
 
     /**
@@ -1766,9 +1778,9 @@ class Linter {
      * @param {ConfigData|ExtractedConfig} config The config array.
      * @param {VerifyOptions&ProcessorOptions} options The options.
      * @param {ConfigArray} [configForRecursive] The `ConfigArray` object to apply multiple processors recursively.
-     * @returns {(LintMessage|SuppressedLintMessage)[]} The found problems.
+     * @returns {Promise<(LintMessage|SuppressedLintMessage)[]>} The found problems.
      */
-    _verifyWithProcessor(textOrSourceCode, config, options, configForRecursive) {
+    async _verifyWithProcessor(textOrSourceCode, config, options, configForRecursive) {
         const filename = options.filename || "<input>";
         const filenameToExpose = normalizeFilename(filename);
         const physicalFilename = options.physicalFilename || filenameToExpose;
@@ -1804,12 +1816,12 @@ class Linter {
             ];
         }
 
-        const messageLists = blocks.map((block, i) => {
+        const messageLists = await mapAsync(blocks, async (block, i) => {
             debug("A code block was found: %o", block.filename || "(unnamed)");
 
             // Keep the legacy behavior.
             if (typeof block === "string") {
-                return this._verifyWithoutProcessors(block, config, options);
+                return await this._verifyWithoutProcessors(block, config, options);
             }
 
             const blockText = block.text;
@@ -1824,7 +1836,7 @@ class Linter {
             // Resolve configuration again if the file content or extension was changed.
             if (configForRecursive && (text !== blockText || path.extname(blockName) !== originalExtname)) {
                 debug("Resolving configuration again because the file content or extension was changed.");
-                return this._verifyWithConfigArray(
+                return await this._verifyWithConfigArray(
                     blockText,
                     configForRecursive,
                     { ...options, filename: blockName, physicalFilename }
@@ -1832,7 +1844,7 @@ class Linter {
             }
 
             // Does lint.
-            return this._verifyWithoutProcessors(
+            return await this._verifyWithoutProcessors(
                 blockText,
                 config,
                 { ...options, filename: blockName, physicalFilename }
@@ -1942,7 +1954,7 @@ class Linter {
      * @returns {{fixed:boolean,messages:LintMessage[],output:string}} The result of the fix operation as returned from the
      *      SourceCodeFixer.
      */
-    verifyAndFix(text, config, options) {
+    async verifyAndFix(text, config, options) {
         let messages = [],
             fixedResult,
             fixed = false,
@@ -1964,7 +1976,7 @@ class Linter {
             passNumber++;
 
             debug(`Linting code for ${debugTextDescription} (pass ${passNumber})`);
-            messages = this.verify(currentText, config, options);
+            messages = await this.verify(currentText, config, options);
 
             debug(`Generating fixed text for ${debugTextDescription} (pass ${passNumber})`);
             fixedResult = SourceCodeFixer.applyFixes(currentText, messages, shouldFix);
@@ -1993,7 +2005,7 @@ class Linter {
          * the most up-to-date information.
          */
         if (fixedResult.fixed) {
-            fixedResult.messages = this.verify(currentText, config, options);
+            fixedResult.messages = await this.verify(currentText, config, options);
         }
 
         // ensure the last result properly reflects if fixes were done

--- a/lib/linter/timing.js
+++ b/lib/linter/timing.js
@@ -136,9 +136,9 @@ module.exports = (function() {
             data[key] = 0;
         }
 
-        return function(...args) {
+        return async function(...args) {
             let t = process.hrtime();
-            const result = fn(...args);
+            const result = await fn(...args);
 
             t = process.hrtime(t);
             data[key] += t[0] * 1e3 + t[1] / 1e6;

--- a/lib/rule-tester/flat-rule-tester.js
+++ b/lib/rule-tester/flat-rule-tester.js
@@ -455,7 +455,7 @@ class FlatRuleTester {
      * scenario of the given type is missing.
      * @returns {void}
      */
-    run(ruleName, rule, test) {
+    async run(ruleName, rule, test) {
 
         const testerConfig = this.testerConfig,
             requiredScenarios = ["valid", "invalid"],
@@ -508,14 +508,14 @@ class FlatRuleTester {
                             [ruleName]: Object.assign({}, rule, {
 
                                 // Create a wrapper rule that freezes the `context` properties.
-                                create(context) {
+                                async create(context) {
                                     freezeDeeply(context.options);
                                     freezeDeeply(context.settings);
                                     freezeDeeply(context.parserOptions);
 
                                     // freezeDeeply(context.languageOptions);
 
-                                    return (typeof rule === "function" ? rule : rule.create)(context);
+                                    return (await (typeof rule === "function" ? rule : rule.create))(context);
                                 }
                             })
                         }
@@ -535,7 +535,7 @@ class FlatRuleTester {
          * @returns {Object} Eslint run result
          * @private
          */
-        function runRuleForItem(item) {
+        async function runRuleForItem(item) {
             const configs = new FlatConfigArray(testerConfig, { baseConfig });
 
             /*
@@ -676,7 +676,7 @@ class FlatRuleTester {
 
             try {
                 SourceCode.prototype.getComments = getCommentsDeprecation;
-                messages = linter.verify(code, configs, filename);
+                messages = await linter.verify(code, configs, filename);
             } finally {
                 SourceCode.prototype.getComments = getComments;
             }
@@ -688,7 +688,7 @@ class FlatRuleTester {
             // Verify if autofix makes a syntax error or not.
             if (messages.some(m => m.fix)) {
                 output = SourceCodeFixer.applyFixes(code, messages).output;
-                const errorMessageInFix = linter.verify(output, configs, filename).find(m => m.fatal);
+                const errorMessageInFix = (await linter.verify(output, configs, filename)).find(m => m.fatal);
 
                 assert(!errorMessageInFix, [
                     "A fatal parsing error occurred in autofix.",
@@ -728,7 +728,7 @@ class FlatRuleTester {
          * @returns {void}
          * @private
          */
-        function testValidTemplate(item) {
+        async function testValidTemplate(item) {
             const code = typeof item === "object" ? item.code : item;
 
             assert.ok(typeof code === "string", "Test case must specify a string value for 'code'");
@@ -736,7 +736,7 @@ class FlatRuleTester {
                 assert.ok(typeof item.name === "string", "Optional test case property 'name' must be a string");
             }
 
-            const result = runRuleForItem(item);
+            const result = await runRuleForItem(item);
             const messages = result.messages;
 
             assert.strictEqual(messages.length, 0, util.format("Should have no errors but had %d: %s",
@@ -775,7 +775,7 @@ class FlatRuleTester {
          * @returns {void}
          * @private
          */
-        function testInvalidTemplate(item) {
+        async function testInvalidTemplate(item) {
             assert.ok(typeof item.code === "string", "Test case must specify a string value for 'code'");
             if (item.name) {
                 assert.ok(typeof item.name === "string", "Optional test case property 'name' must be a string");
@@ -790,7 +790,7 @@ class FlatRuleTester {
             const ruleHasMetaMessages = hasOwnProperty(rule, "meta") && hasOwnProperty(rule.meta, "messages");
             const friendlyIDList = ruleHasMetaMessages ? `[${Object.keys(rule.meta.messages).map(key => `'${key}'`).join(", ")}]` : null;
 
-            const result = runRuleForItem(item);
+            const result = await runRuleForItem(item);
             const messages = result.messages;
 
             if (typeof item.errors === "number") {
@@ -1012,27 +1012,27 @@ class FlatRuleTester {
          * This creates a mocha test suite and pipes all supplied info through
          * one of the templates above.
          */
-        this.constructor.describe(ruleName, () => {
-            this.constructor.describe("valid", () => {
-                test.valid.forEach(valid => {
-                    this.constructor[valid.only ? "itOnly" : "it"](
+        await this.constructor.describe(ruleName, async () => {
+            await this.constructor.describe("valid", async () => {
+                for (const valid of test.valid) {
+                    await this.constructor[valid.only ? "itOnly" : "it"](
                         sanitize(typeof valid === "object" ? valid.name || valid.code : valid),
-                        () => {
-                            testValidTemplate(valid);
+                        async () => {
+                            await testValidTemplate(valid);
                         }
                     );
-                });
+                }
             });
 
-            this.constructor.describe("invalid", () => {
-                test.invalid.forEach(invalid => {
-                    this.constructor[invalid.only ? "itOnly" : "it"](
+            await this.constructor.describe("invalid", async () => {
+                for (const invalid of test.invalid) {
+                    await this.constructor[invalid.only ? "itOnly" : "it"](
                         sanitize(invalid.name || invalid.code),
-                        () => {
-                            testInvalidTemplate(invalid);
+                        async () => {
+                            await testInvalidTemplate(invalid);
                         }
                     );
-                });
+                }
             });
         });
     }

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -527,7 +527,7 @@ class RuleTester {
      * scenario of the given type is missing.
      * @returns {void}
      */
-    run(ruleName, rule, test) {
+    async run(ruleName, rule, test) {
 
         const testerConfig = this.testerConfig,
             requiredScenarios = ["valid", "invalid"],
@@ -557,12 +557,12 @@ class RuleTester {
         linter.defineRule(ruleName, Object.assign({}, rule, {
 
             // Create a wrapper rule that freezes the `context` properties.
-            create(context) {
+            async create(context) {
                 freezeDeeply(context.options);
                 freezeDeeply(context.settings);
                 freezeDeeply(context.parserOptions);
 
-                return (typeof rule === "function" ? rule : rule.create)(context);
+                return (await (typeof rule === "function" ? rule : rule.create))(context);
             }
         }));
 
@@ -575,7 +575,7 @@ class RuleTester {
          * @returns {Object} Eslint run result
          * @private
          */
-        function runRuleForItem(item) {
+        async function runRuleForItem(item) {
             let config = merge({}, testerConfig),
                 code, filename, output, beforeAST, afterAST;
 
@@ -686,7 +686,7 @@ class RuleTester {
 
             try {
                 SourceCode.prototype.getComments = getCommentsDeprecation;
-                messages = linter.verify(code, config, filename);
+                messages = await linter.verify(code, config, filename);
             } finally {
                 SourceCode.prototype.getComments = getComments;
             }
@@ -698,7 +698,7 @@ class RuleTester {
             // Verify if autofix makes a syntax error or not.
             if (messages.some(m => m.fix)) {
                 output = SourceCodeFixer.applyFixes(code, messages).output;
-                const errorMessageInFix = linter.verify(output, config, filename).find(m => m.fatal);
+                const errorMessageInFix = (await linter.verify(output, config, filename)).find(m => m.fatal);
 
                 assert(!errorMessageInFix, [
                     "A fatal parsing error occurred in autofix.",
@@ -738,7 +738,7 @@ class RuleTester {
          * @returns {void}
          * @private
          */
-        function testValidTemplate(item) {
+        async function testValidTemplate(item) {
             const code = typeof item === "object" ? item.code : item;
 
             assert.ok(typeof code === "string", "Test case must specify a string value for 'code'");
@@ -746,7 +746,7 @@ class RuleTester {
                 assert.ok(typeof item.name === "string", "Optional test case property 'name' must be a string");
             }
 
-            const result = runRuleForItem(item);
+            const result = await runRuleForItem(item);
             const messages = result.messages;
 
             assert.strictEqual(messages.length, 0, util.format("Should have no errors but had %d: %s",
@@ -785,7 +785,7 @@ class RuleTester {
          * @returns {void}
          * @private
          */
-        function testInvalidTemplate(item) {
+        async function testInvalidTemplate(item) {
             assert.ok(typeof item.code === "string", "Test case must specify a string value for 'code'");
             if (item.name) {
                 assert.ok(typeof item.name === "string", "Optional test case property 'name' must be a string");
@@ -800,7 +800,7 @@ class RuleTester {
             const ruleHasMetaMessages = hasOwnProperty(rule, "meta") && hasOwnProperty(rule.meta, "messages");
             const friendlyIDList = ruleHasMetaMessages ? `[${Object.keys(rule.meta.messages).map(key => `'${key}'`).join(", ")}]` : null;
 
-            const result = runRuleForItem(item);
+            const result = await runRuleForItem(item);
             const messages = result.messages;
 
             if (typeof item.errors === "number") {
@@ -1022,27 +1022,27 @@ class RuleTester {
          * This creates a mocha test suite and pipes all supplied info through
          * one of the templates above.
          */
-        this.constructor.describe(ruleName, () => {
-            this.constructor.describe("valid", () => {
-                test.valid.forEach(valid => {
-                    this.constructor[valid.only ? "itOnly" : "it"](
+        await this.constructor.describe(ruleName, async () => {
+            await this.constructor.describe("valid", async () => {
+                for (const valid of test.valid) {
+                    await this.constructor[valid.only ? "itOnly" : "it"](
                         sanitize(typeof valid === "object" ? valid.name || valid.code : valid),
-                        () => {
-                            testValidTemplate(valid);
+                        async () => {
+                            await testValidTemplate(valid);
                         }
                     );
-                });
+                }
             });
 
-            this.constructor.describe("invalid", () => {
-                test.invalid.forEach(invalid => {
-                    this.constructor[invalid.only ? "itOnly" : "it"](
+            await this.constructor.describe("invalid", async () => {
+                for (const invalid of test.invalid) {
+                    await this.constructor[invalid.only ? "itOnly" : "it"](
                         sanitize(invalid.name || invalid.code),
-                        () => {
-                            testInvalidTemplate(invalid);
+                        async () => {
+                            await testInvalidTemplate(invalid);
                         }
                     );
-                });
+                }
             });
         });
     }

--- a/tests/lib/cli-engine/cli-engine.js
+++ b/tests/lib/cli-engine/cli-engine.js
@@ -10,6 +10,7 @@
 //------------------------------------------------------------------------------
 
 const assert = require("chai").assert,
+    nodeAssert = require("assert"),
     path = require("path"),
     sinon = require("sinon"),
     shell = require("shelljs"),
@@ -105,7 +106,7 @@ describe("CLIEngine", () => {
     });
 
     describe("new CLIEngine(options)", () => {
-        it("the default value of 'options.cwd' should be the current working directory.", () => {
+        it("the default value of 'options.cwd' should be the current working directory.", async () => {
             process.chdir(__dirname);
             try {
                 const engine = new CLIEngine();
@@ -117,7 +118,7 @@ describe("CLIEngine", () => {
             }
         });
 
-        it("should report one fatal message when given a path by --ignore-path that is not a file when ignore is true.", () => {
+        it("should report one fatal message when given a path by --ignore-path that is not a file when ignore is true.", async () => {
             assert.throws(() => {
                 // eslint-disable-next-line no-new -- Testing synchronous throwing
                 new CLIEngine({ ignorePath: fixtureDir });
@@ -125,7 +126,7 @@ describe("CLIEngine", () => {
         });
 
         // https://github.com/eslint/eslint/issues/2380
-        it("should not modify baseConfig when format is specified", () => {
+        it("should not modify baseConfig when format is specified", async () => {
             const customBaseConfig = { root: true };
 
             new CLIEngine({ baseConfig: customBaseConfig, format: "foo" }); // eslint-disable-line no-new -- Test side effects
@@ -162,11 +163,11 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("should report the total and per file errors", () => {
+            it("should report the total and per file errors", async () => {
 
                 engine = new CLIEngine({ cwd: getPath() });
 
-                const report = engine.executeOnText("var foo = 'bar';");
+                const report = await engine.executeOnText("var foo = 'bar';");
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.errorCount, 5);
@@ -185,7 +186,7 @@ describe("CLIEngine", () => {
                 assert.strictEqual(report.results[0].suppressedMessages.length, 0);
             });
 
-            it("should report the total and per file warnings", () => {
+            it("should report the total and per file warnings", async () => {
 
                 engine = new CLIEngine({
                     cwd: getPath(),
@@ -198,7 +199,7 @@ describe("CLIEngine", () => {
                     }
                 });
 
-                const report = engine.executeOnText("var foo = 'bar';");
+                const report = await engine.executeOnText("var foo = 'bar';");
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.errorCount, 0);
@@ -217,7 +218,7 @@ describe("CLIEngine", () => {
             });
         });
 
-        it("should report one message when using specific config file", () => {
+        it("should report one message when using specific config file", async () => {
 
             engine = new CLIEngine({
                 configFile: "fixtures/configurations/quotes-error.json",
@@ -225,7 +226,7 @@ describe("CLIEngine", () => {
                 cwd: getFixturePath("..")
             });
 
-            const report = engine.executeOnText("var foo = 'bar';");
+            const report = await engine.executeOnText("var foo = 'bar';");
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.errorCount, 1);
@@ -241,26 +242,26 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should report the filename when passed in", () => {
+        it("should report the filename when passed in", async () => {
 
             engine = new CLIEngine({
                 ignore: false,
                 cwd: getFixturePath()
             });
 
-            const report = engine.executeOnText("var foo = 'bar';", "test.js");
+            const report = await engine.executeOnText("var foo = 'bar';", "test.js");
 
             assert.strictEqual(report.results[0].filePath, getFixturePath("test.js"));
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should return a warning when given a filename by --stdin-filename in excluded files list if warnIgnored is true", () => {
+        it("should return a warning when given a filename by --stdin-filename in excluded files list if warnIgnored is true", async () => {
             engine = new CLIEngine({
                 ignorePath: getFixturePath(".eslintignore"),
                 cwd: getFixturePath("..")
             });
 
-            const report = engine.executeOnText("var bar = foo;", "fixtures/passing.js", true);
+            const report = await engine.executeOnText("var bar = foo;", "fixtures/passing.js", true);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.errorCount, 0);
@@ -280,32 +281,32 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should not return a warning when given a filename by --stdin-filename in excluded files list if warnIgnored is false", () => {
+        it("should not return a warning when given a filename by --stdin-filename in excluded files list if warnIgnored is false", async () => {
             engine = new CLIEngine({
                 ignorePath: getFixturePath(".eslintignore"),
                 cwd: getFixturePath("..")
             });
 
             // intentional parsing error
-            const report = engine.executeOnText("va r bar = foo;", "fixtures/passing.js", false);
+            const report = await engine.executeOnText("va r bar = foo;", "fixtures/passing.js", false);
 
             // should not report anything because the file is ignored
             assert.strictEqual(report.results.length, 0);
         });
 
-        it("should suppress excluded file warnings by default", () => {
+        it("should suppress excluded file warnings by default", async () => {
             engine = new CLIEngine({
                 ignorePath: getFixturePath(".eslintignore"),
                 cwd: getFixturePath("..")
             });
 
-            const report = engine.executeOnText("var bar = foo;", "fixtures/passing.js");
+            const report = await engine.executeOnText("var bar = foo;", "fixtures/passing.js");
 
             // should not report anything because there are no errors
             assert.strictEqual(report.results.length, 0);
         });
 
-        it("should return a message when given a filename by --stdin-filename in excluded files list and ignore is off", () => {
+        it("should return a message when given a filename by --stdin-filename in excluded files list and ignore is off", async () => {
 
             engine = new CLIEngine({
                 ignorePath: "fixtures/.eslintignore",
@@ -317,7 +318,7 @@ describe("CLIEngine", () => {
                 }
             });
 
-            const report = engine.executeOnText("var bar = foo;", "fixtures/passing.js");
+            const report = await engine.executeOnText("var bar = foo;", "fixtures/passing.js");
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].filePath, getFixturePath("passing.js"));
@@ -327,7 +328,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should return a message and fixed text when in fix mode", () => {
+        it("should return a message and fixed text when in fix mode", async () => {
 
             engine = new CLIEngine({
                 useEslintrc: false,
@@ -339,7 +340,7 @@ describe("CLIEngine", () => {
                 cwd: getFixturePath()
             });
 
-            const report = engine.executeOnText("var bar = foo", "passing.js");
+            const report = await engine.executeOnText("var bar = foo", "passing.js");
 
             assert.deepStrictEqual(report, {
                 results: [
@@ -364,7 +365,7 @@ describe("CLIEngine", () => {
             });
         });
 
-        it("correctly autofixes semicolon-conflicting-fixes", () => {
+        it("correctly autofixes semicolon-conflicting-fixes", async () => {
             engine = new CLIEngine({
                 cwd: path.join(fixtureDir, ".."),
                 useEslintrc: false,
@@ -372,14 +373,14 @@ describe("CLIEngine", () => {
             });
             const inputPath = getFixturePath("autofix/semicolon-conflicting-fixes.js");
             const outputPath = getFixturePath("autofix/semicolon-conflicting-fixes.expected.js");
-            const report = engine.executeOnFiles([inputPath]);
+            const report = await engine.executeOnFiles([inputPath]);
             const expectedOutput = fs.readFileSync(outputPath, "utf8");
 
             assert.strictEqual(report.results[0].output, expectedOutput);
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("correctly autofixes return-conflicting-fixes", () => {
+        it("correctly autofixes return-conflicting-fixes", async () => {
             engine = new CLIEngine({
                 cwd: path.join(fixtureDir, ".."),
                 useEslintrc: false,
@@ -387,7 +388,7 @@ describe("CLIEngine", () => {
             });
             const inputPath = getFixturePath("autofix/return-conflicting-fixes.js");
             const outputPath = getFixturePath("autofix/return-conflicting-fixes.expected.js");
-            const report = engine.executeOnFiles([inputPath]);
+            const report = await engine.executeOnFiles([inputPath]);
             const expectedOutput = fs.readFileSync(outputPath, "utf8");
 
             assert.strictEqual(report.results[0].output, expectedOutput);
@@ -396,7 +397,7 @@ describe("CLIEngine", () => {
 
         describe("Fix Types", () => {
 
-            it("should throw an error when an invalid fix type is specified", () => {
+            it("should throw an error when an invalid fix type is specified", async () => {
                 assert.throws(() => {
                     engine = new CLIEngine({
                         cwd: path.join(fixtureDir, ".."),
@@ -407,7 +408,7 @@ describe("CLIEngine", () => {
                 }, /invalid fix type/iu);
             });
 
-            it("should not fix any rules when fixTypes is used without fix", () => {
+            it("should not fix any rules when fixTypes is used without fix", async () => {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
@@ -416,12 +417,12 @@ describe("CLIEngine", () => {
                 });
 
                 const inputPath = getFixturePath("fix-types/fix-only-semi.js");
-                const report = engine.executeOnFiles([inputPath]);
+                const report = await engine.executeOnFiles([inputPath]);
 
                 assert.isUndefined(report.results[0].output);
             });
 
-            it("should not fix non-style rules when fixTypes has only 'layout'", () => {
+            it("should not fix non-style rules when fixTypes has only 'layout'", async () => {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
@@ -430,13 +431,13 @@ describe("CLIEngine", () => {
                 });
                 const inputPath = getFixturePath("fix-types/fix-only-semi.js");
                 const outputPath = getFixturePath("fix-types/fix-only-semi.expected.js");
-                const report = engine.executeOnFiles([inputPath]);
+                const report = await engine.executeOnFiles([inputPath]);
                 const expectedOutput = fs.readFileSync(outputPath, "utf8");
 
                 assert.strictEqual(report.results[0].output, expectedOutput);
             });
 
-            it("should not fix style or problem rules when fixTypes has only 'suggestion'", () => {
+            it("should not fix style or problem rules when fixTypes has only 'suggestion'", async () => {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
@@ -445,13 +446,13 @@ describe("CLIEngine", () => {
                 });
                 const inputPath = getFixturePath("fix-types/fix-only-prefer-arrow-callback.js");
                 const outputPath = getFixturePath("fix-types/fix-only-prefer-arrow-callback.expected.js");
-                const report = engine.executeOnFiles([inputPath]);
+                const report = await engine.executeOnFiles([inputPath]);
                 const expectedOutput = fs.readFileSync(outputPath, "utf8");
 
                 assert.strictEqual(report.results[0].output, expectedOutput);
             });
 
-            it("should fix both style and problem rules when fixTypes has 'suggestion' and 'layout'", () => {
+            it("should fix both style and problem rules when fixTypes has 'suggestion' and 'layout'", async () => {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
@@ -460,13 +461,13 @@ describe("CLIEngine", () => {
                 });
                 const inputPath = getFixturePath("fix-types/fix-both-semi-and-prefer-arrow-callback.js");
                 const outputPath = getFixturePath("fix-types/fix-both-semi-and-prefer-arrow-callback.expected.js");
-                const report = engine.executeOnFiles([inputPath]);
+                const report = await engine.executeOnFiles([inputPath]);
                 const expectedOutput = fs.readFileSync(outputPath, "utf8");
 
                 assert.strictEqual(report.results[0].output, expectedOutput);
             });
 
-            it("should not throw an error when a rule doesn't have a 'meta' property", () => {
+            it("should not throw an error when a rule doesn't have a 'meta' property", async () => {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
@@ -477,13 +478,13 @@ describe("CLIEngine", () => {
 
                 const inputPath = getFixturePath("fix-types/ignore-missing-meta.js");
                 const outputPath = getFixturePath("fix-types/ignore-missing-meta.expected.js");
-                const report = engine.executeOnFiles([inputPath]);
+                const report = await engine.executeOnFiles([inputPath]);
                 const expectedOutput = fs.readFileSync(outputPath, "utf8");
 
                 assert.strictEqual(report.results[0].output, expectedOutput);
             });
 
-            it("should not throw an error when a rule is loaded after initialization with executeOnFiles()", () => {
+            it("should not throw an error when a rule is loaded after initialization with executeOnFiles()", async () => {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
@@ -499,13 +500,13 @@ describe("CLIEngine", () => {
 
                 const inputPath = getFixturePath("fix-types/ignore-missing-meta.js");
                 const outputPath = getFixturePath("fix-types/ignore-missing-meta.expected.js");
-                const report = engine.executeOnFiles([inputPath]);
+                const report = await engine.executeOnFiles([inputPath]);
                 const expectedOutput = fs.readFileSync(outputPath, "utf8");
 
                 assert.strictEqual(report.results[0].output, expectedOutput);
             });
 
-            it("should not throw an error when a rule is loaded after initialization with executeOnText()", () => {
+            it("should not throw an error when a rule is loaded after initialization with executeOnText()", async () => {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
@@ -521,7 +522,7 @@ describe("CLIEngine", () => {
 
                 const inputPath = getFixturePath("fix-types/ignore-missing-meta.js");
                 const outputPath = getFixturePath("fix-types/ignore-missing-meta.expected.js");
-                const report = engine.executeOnText(fs.readFileSync(inputPath, { encoding: "utf8" }), inputPath);
+                const report = await engine.executeOnText(fs.readFileSync(inputPath, { encoding: "utf8" }), inputPath);
                 const expectedOutput = fs.readFileSync(outputPath, "utf8");
 
                 assert.strictEqual(report.results[0].output, expectedOutput);
@@ -529,7 +530,7 @@ describe("CLIEngine", () => {
 
         });
 
-        it("should return a message and omit fixed text when in fix mode and fixes aren't done", () => {
+        it("should return a message and omit fixed text when in fix mode and fixes aren't done", async () => {
 
             engine = new CLIEngine({
                 useEslintrc: false,
@@ -541,7 +542,7 @@ describe("CLIEngine", () => {
                 cwd: getFixturePath()
             });
 
-            const report = engine.executeOnText("var bar = foo", "passing.js");
+            const report = await engine.executeOnText("var bar = foo", "passing.js");
 
             assert.deepStrictEqual(report, {
                 results: [
@@ -578,7 +579,7 @@ describe("CLIEngine", () => {
             });
         });
 
-        it("should not delete code if there is a syntax error after trying to autofix.", () => {
+        it("should not delete code if there is a syntax error after trying to autofix.", async () => {
             engine = cliEngineWithPlugins({
                 useEslintrc: false,
                 fix: true,
@@ -590,7 +591,7 @@ describe("CLIEngine", () => {
                 cwd: getFixturePath()
             });
 
-            const report = engine.executeOnText("var bar = foo", "test.js");
+            const report = await engine.executeOnText("var bar = foo", "test.js");
 
             assert.deepStrictEqual(report, {
                 results: [
@@ -625,7 +626,7 @@ describe("CLIEngine", () => {
             });
         });
 
-        it("should not crash even if there are any syntax error since the first time.", () => {
+        it("should not crash even if there are any syntax error since the first time.", async () => {
             engine = new CLIEngine({
                 useEslintrc: false,
                 fix: true,
@@ -636,7 +637,7 @@ describe("CLIEngine", () => {
                 cwd: getFixturePath()
             });
 
-            const report = engine.executeOnText("var bar =", "test.js");
+            const report = await engine.executeOnText("var bar =", "test.js");
 
             assert.deepStrictEqual(report, {
                 results: [
@@ -671,42 +672,42 @@ describe("CLIEngine", () => {
             });
         });
 
-        it("should return source code of file in `source` property when errors are present", () => {
+        it("should return source code of file in `source` property when errors are present", async () => {
             engine = new CLIEngine({
                 useEslintrc: false,
                 rules: { semi: 2 }
             });
 
-            const report = engine.executeOnText("var foo = 'bar'");
+            const report = await engine.executeOnText("var foo = 'bar'");
 
             assert.strictEqual(report.results[0].source, "var foo = 'bar'");
         });
 
-        it("should return source code of file in `source` property when warnings are present", () => {
+        it("should return source code of file in `source` property when warnings are present", async () => {
             engine = new CLIEngine({
                 useEslintrc: false,
                 rules: { semi: 1 }
             });
 
-            const report = engine.executeOnText("var foo = 'bar'");
+            const report = await engine.executeOnText("var foo = 'bar'");
 
             assert.strictEqual(report.results[0].source, "var foo = 'bar'");
         });
 
 
-        it("should not return a `source` property when no errors or warnings are present", () => {
+        it("should not return a `source` property when no errors or warnings are present", async () => {
             engine = new CLIEngine({
                 useEslintrc: false,
                 rules: { semi: 2 }
             });
 
-            const report = engine.executeOnText("var foo = 'bar';");
+            const report = await engine.executeOnText("var foo = 'bar';");
 
             assert.lengthOf(report.results[0].messages, 0);
             assert.isUndefined(report.results[0].source);
         });
 
-        it("should not return a `source` property when fixes are applied", () => {
+        it("should not return a `source` property when fixes are applied", async () => {
             engine = new CLIEngine({
                 useEslintrc: false,
                 fix: true,
@@ -716,19 +717,19 @@ describe("CLIEngine", () => {
                 }
             });
 
-            const report = engine.executeOnText("var msg = 'hi' + foo\n");
+            const report = await engine.executeOnText("var msg = 'hi' + foo\n");
 
             assert.isUndefined(report.results[0].source);
             assert.strictEqual(report.results[0].output, "var msg = 'hi' + foo;\n");
         });
 
-        it("should return a `source` property when a parsing error has occurred", () => {
+        it("should return a `source` property when a parsing error has occurred", async () => {
             engine = new CLIEngine({
                 useEslintrc: false,
                 rules: { semi: 2 }
             });
 
-            const report = engine.executeOnText("var bar = foothis is a syntax error.\n return bar;");
+            const report = await engine.executeOnText("var bar = foothis is a syntax error.\n return bar;");
 
             assert.deepStrictEqual(report, {
                 results: [
@@ -764,14 +765,14 @@ describe("CLIEngine", () => {
         });
 
         // https://github.com/eslint/eslint/issues/5547
-        it("should respect default ignore rules, even with --no-ignore", () => {
+        it("should respect default ignore rules, even with --no-ignore", async () => {
 
             engine = new CLIEngine({
                 cwd: getFixturePath(),
                 ignore: false
             });
 
-            const report = engine.executeOnText("var bar = foo;", "node_modules/passing.js", true);
+            const report = await engine.executeOnText("var bar = foo;", "node_modules/passing.js", true);
             const expectedMsg = "File ignored by default. Use \"--ignore-pattern '!node_modules/*'\" to override.";
 
             assert.strictEqual(report.results.length, 1);
@@ -800,9 +801,9 @@ describe("CLIEngine", () => {
             });
             /* eslint-enable no-underscore-dangle -- Private Node API overriding */
 
-            it("should resolve 'plugins:[\"@scope\"]' to 'node_modules/@scope/eslint-plugin'.", () => {
+            it("should resolve 'plugins:[\"@scope\"]' to 'node_modules/@scope/eslint-plugin'.", async () => {
                 engine = new CLIEngine({ cwd: getFixturePath("plugin-shorthand/basic") });
-                const report = engine.executeOnText("var x = 0", "index.js").results[0];
+                const report = (await engine.executeOnText("var x = 0", "index.js")).results[0];
 
                 assert.strictEqual(report.filePath, getFixturePath("plugin-shorthand/basic/index.js"));
                 assert.strictEqual(report.messages[0].ruleId, "@scope/rule");
@@ -810,9 +811,9 @@ describe("CLIEngine", () => {
                 assert.strictEqual(report.suppressedMessages.length, 0);
             });
 
-            it("should resolve 'extends:[\"plugin:@scope/recommended\"]' to 'node_modules/@scope/eslint-plugin'.", () => {
+            it("should resolve 'extends:[\"plugin:@scope/recommended\"]' to 'node_modules/@scope/eslint-plugin'.", async () => {
                 engine = new CLIEngine({ cwd: getFixturePath("plugin-shorthand/extends") });
-                const report = engine.executeOnText("var x = 0", "index.js").results[0];
+                const report = (await engine.executeOnText("var x = 0", "index.js")).results[0];
 
                 assert.strictEqual(report.filePath, getFixturePath("plugin-shorthand/extends/index.js"));
                 assert.strictEqual(report.messages[0].ruleId, "@scope/rule");
@@ -820,14 +821,14 @@ describe("CLIEngine", () => {
                 assert.strictEqual(report.suppressedMessages.length, 0);
             });
         });
-        it("should warn when deprecated rules are found in a config", () => {
+        it("should warn when deprecated rules are found in a config", async () => {
             engine = new CLIEngine({
                 cwd: originalDir,
                 useEslintrc: false,
                 configFile: "tests/fixtures/cli-engine/deprecated-rule-config/.eslintrc.yml"
             });
 
-            const report = engine.executeOnText("foo");
+            const report = await engine.executeOnText("foo");
 
             assert.deepStrictEqual(
                 report.usedDeprecatedRules,
@@ -842,7 +843,7 @@ describe("CLIEngine", () => {
         /** @type {InstanceType<import("../../../lib/cli-engine").CLIEngine>} */
         let engine;
 
-        it("should use correct parser when custom parser is specified", () => {
+        it("should use correct parser when custom parser is specified", async () => {
 
             engine = new CLIEngine({
                 cwd: originalDir,
@@ -850,7 +851,7 @@ describe("CLIEngine", () => {
             });
 
             const filePath = path.resolve(__dirname, "../../fixtures/configurations/parser/custom.js");
-            const report = engine.executeOnFiles([filePath]);
+            const report = await engine.executeOnFiles([filePath]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].messages.length, 1);
@@ -858,7 +859,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should report zero messages when given a config file and a valid file", () => {
+        it("should report zero messages when given a config file and a valid file", async () => {
 
             engine = new CLIEngine({
                 cwd: originalDir,
@@ -867,7 +868,7 @@ describe("CLIEngine", () => {
                 overrideConfigFile: "tests/fixtures/simple-valid-project/.eslintrc.js"
             });
 
-            const report = engine.executeOnFiles(["tests/fixtures/simple-valid-project/**/foo*.js"]);
+            const report = await engine.executeOnFiles(["tests/fixtures/simple-valid-project/**/foo*.js"]);
 
             assert.strictEqual(report.results.length, 2);
             assert.strictEqual(report.results[0].messages.length, 0);
@@ -875,7 +876,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should handle multiple patterns with overlapping files", () => {
+        it("should handle multiple patterns with overlapping files", async () => {
 
             engine = new CLIEngine({
                 cwd: originalDir,
@@ -884,7 +885,7 @@ describe("CLIEngine", () => {
                 overrideConfigFile: "tests/fixtures/simple-valid-project/.eslintrc.js"
             });
 
-            const report = engine.executeOnFiles([
+            const report = await engine.executeOnFiles([
                 "tests/fixtures/simple-valid-project/**/foo*.js",
                 "tests/fixtures/simple-valid-project/foo.?s",
                 "tests/fixtures/simple-valid-project/{foo,src/foobar}.js"
@@ -897,7 +898,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[1].suppressedMessages.length, 0);
         });
 
-        it("should report zero messages when given a config file and a valid file and espree as parser", () => {
+        it("should report zero messages when given a config file and a valid file and espree as parser", async () => {
 
             engine = new CLIEngine({
                 parser: "espree",
@@ -907,59 +908,59 @@ describe("CLIEngine", () => {
                 useEslintrc: false
             });
 
-            const report = engine.executeOnFiles(["lib/cli.js"]);
+            const report = await engine.executeOnFiles(["lib/cli.js"]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].messages.length, 0);
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should report zero messages when given a config file and a valid file and esprima as parser", () => {
+        it("should report zero messages when given a config file and a valid file and esprima as parser", async () => {
 
             engine = new CLIEngine({
                 parser: "esprima",
                 useEslintrc: false
             });
 
-            const report = engine.executeOnFiles(["lib/cli.js"]);
+            const report = await engine.executeOnFiles(["lib/cli.js"]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].messages.length, 0);
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should throw an error when given a config file and a valid file and invalid parser", () => {
+        it("should throw an error when given a config file and a valid file and invalid parser", async () => {
 
             engine = new CLIEngine({
                 parser: "test11",
                 useEslintrc: false
             });
 
-            assert.throws(() => engine.executeOnFiles(["lib/cli.js"]), "Cannot find module 'test11'");
+            await nodeAssert.rejects(async () => await engine.executeOnFiles(["lib/cli.js"]), /Cannot find module 'test11'/u);
         });
 
-        it("should report zero messages when given a directory with a .js2 file", () => {
+        it("should report zero messages when given a directory with a .js2 file", async () => {
 
             engine = new CLIEngine({
                 cwd: path.join(fixtureDir, ".."),
                 extensions: [".js2"]
             });
 
-            const report = engine.executeOnFiles([getFixturePath("files/foo.js2")]);
+            const report = await engine.executeOnFiles([getFixturePath("files/foo.js2")]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].messages.length, 0);
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should fall back to defaults when extensions is set to an empty array", () => {
+        it("should fall back to defaults when extensions is set to an empty array", async () => {
 
             engine = new CLIEngine({
                 cwd: getFixturePath("configurations"),
                 configFile: getFixturePath("configurations", "quotes-error.json"),
                 extensions: []
             });
-            const report = engine.executeOnFiles([getFixturePath("single-quoted.js")]);
+            const report = await engine.executeOnFiles([getFixturePath("single-quoted.js")]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].messages.length, 1);
@@ -976,7 +977,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should report zero messages when given a directory with a .js and a .js2 file", () => {
+        it("should report zero messages when given a directory with a .js and a .js2 file", async () => {
 
             engine = new CLIEngine({
                 extensions: [".js", ".js2"],
@@ -984,7 +985,7 @@ describe("CLIEngine", () => {
                 cwd: getFixturePath("..")
             });
 
-            const report = engine.executeOnFiles(["fixtures/files/"]);
+            const report = await engine.executeOnFiles(["fixtures/files/"]);
 
             assert.strictEqual(report.results.length, 2);
             assert.strictEqual(report.results[0].messages.length, 0);
@@ -992,7 +993,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should report zero messages when given a '**' pattern with a .js and a .js2 file", () => {
+        it("should report zero messages when given a '**' pattern with a .js and a .js2 file", async () => {
 
             engine = new CLIEngine({
                 extensions: [".js", ".js2"],
@@ -1000,7 +1001,7 @@ describe("CLIEngine", () => {
                 cwd: path.join(fixtureDir, "..")
             });
 
-            const report = engine.executeOnFiles(["fixtures/files/*"]);
+            const report = await engine.executeOnFiles(["fixtures/files/*"]);
 
             assert.strictEqual(report.results.length, 2);
             assert.strictEqual(report.results[0].messages.length, 0);
@@ -1008,14 +1009,14 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should resolve globs when 'globInputPaths' option is true", () => {
+        it("should resolve globs when 'globInputPaths' option is true", async () => {
             engine = new CLIEngine({
                 extensions: [".js", ".js2"],
                 ignore: false,
                 cwd: getFixturePath("..")
             });
 
-            const report = engine.executeOnFiles(["fixtures/files/*"]);
+            const report = await engine.executeOnFiles(["fixtures/files/*"]);
 
             assert.strictEqual(report.results.length, 2);
             assert.strictEqual(report.results[0].messages.length, 0);
@@ -1023,7 +1024,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should not resolve globs when 'globInputPaths' option is false", () => {
+        it("should not resolve globs when 'globInputPaths' option is false", async () => {
             engine = new CLIEngine({
                 extensions: [".js", ".js2"],
                 ignore: false,
@@ -1031,18 +1032,18 @@ describe("CLIEngine", () => {
                 globInputPaths: false
             });
 
-            assert.throws(() => {
-                engine.executeOnFiles(["fixtures/files/*"]);
-            }, "No files matching 'fixtures/files/*' were found (glob was disabled).");
+            await nodeAssert.rejects(async () => {
+                await engine.executeOnFiles(["fixtures/files/*"]);
+            }, /No files matching 'fixtures\/files\/\*' were found \(glob was disabled\)\./u);
         });
 
-        it("should report on all files passed explicitly, even if ignored by default", () => {
+        it("should report on all files passed explicitly, even if ignored by default", async () => {
 
             engine = new CLIEngine({
                 cwd: getFixturePath("cli-engine")
             });
 
-            const report = engine.executeOnFiles(["node_modules/foo.js"]);
+            const report = await engine.executeOnFiles(["node_modules/foo.js"]);
             const expectedMsg = "File ignored by default. Use \"--ignore-pattern '!node_modules/*'\" to override.";
 
             assert.strictEqual(report.results.length, 1);
@@ -1055,7 +1056,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should report on globs with explicit inclusion of dotfiles, even though ignored by default", () => {
+        it("should report on globs with explicit inclusion of dotfiles, even though ignored by default", async () => {
 
             engine = new CLIEngine({
                 cwd: getFixturePath("cli-engine"),
@@ -1064,7 +1065,7 @@ describe("CLIEngine", () => {
                 }
             });
 
-            const report = engine.executeOnFiles(["hidden/.hiddenfolder/*.js"]);
+            const report = await engine.executeOnFiles(["hidden/.hiddenfolder/*.js"]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].errorCount, 1);
@@ -1074,31 +1075,31 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should not check default ignored files without --no-ignore flag", () => {
+        it("should not check default ignored files without --no-ignore flag", async () => {
 
             engine = new CLIEngine({
                 cwd: getFixturePath("cli-engine")
             });
 
-            assert.throws(() => {
-                engine.executeOnFiles(["node_modules"]);
-            }, "All files matched by 'node_modules' are ignored.");
+            await nodeAssert.rejects(async () => {
+                await engine.executeOnFiles(["node_modules"]);
+            }, /All files matched by 'node_modules' are ignored./u);
         });
 
         // https://github.com/eslint/eslint/issues/5547
-        it("should not check node_modules files even with --no-ignore flag", () => {
+        it("should not check node_modules files even with --no-ignore flag", async () => {
 
             engine = new CLIEngine({
                 cwd: getFixturePath("cli-engine"),
                 ignore: false
             });
 
-            assert.throws(() => {
-                engine.executeOnFiles(["node_modules"]);
-            }, "All files matched by 'node_modules' are ignored.");
+            await nodeAssert.rejects(async () => {
+                await engine.executeOnFiles(["node_modules"]);
+            }, /All files matched by 'node_modules' are ignored./u);
         });
 
-        it("should not check .hidden files if they are passed explicitly without --no-ignore flag", () => {
+        it("should not check .hidden files if they are passed explicitly without --no-ignore flag", async () => {
 
             engine = new CLIEngine({
                 cwd: getFixturePath(".."),
@@ -1108,7 +1109,7 @@ describe("CLIEngine", () => {
                 }
             });
 
-            const report = engine.executeOnFiles(["fixtures/files/.bar.js"]);
+            const report = await engine.executeOnFiles(["fixtures/files/.bar.js"]);
             const expectedMsg = "File ignored by default.  Use a negated ignore pattern (like \"--ignore-pattern '!<relative/path/to/filename>'\") to override.";
 
             assert.strictEqual(report.results.length, 1);
@@ -1122,7 +1123,7 @@ describe("CLIEngine", () => {
         });
 
         // https://github.com/eslint/eslint/issues/12873
-        it("should not check files within a .hidden folder if they are passed explicitly without the --no-ignore flag", () => {
+        it("should not check files within a .hidden folder if they are passed explicitly without the --no-ignore flag", async () => {
             engine = new CLIEngine({
                 cwd: getFixturePath("cli-engine"),
                 useEslintrc: false,
@@ -1131,7 +1132,7 @@ describe("CLIEngine", () => {
                 }
             });
 
-            const report = engine.executeOnFiles(["hidden/.hiddenfolder/double-quotes.js"]);
+            const report = await engine.executeOnFiles(["hidden/.hiddenfolder/double-quotes.js"]);
             const expectedMsg = "File ignored by default.  Use a negated ignore pattern (like \"--ignore-pattern '!<relative/path/to/filename>'\") to override.";
 
             assert.strictEqual(report.results.length, 1);
@@ -1144,7 +1145,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should check .hidden files if they are passed explicitly with --no-ignore flag", () => {
+        it("should check .hidden files if they are passed explicitly with --no-ignore flag", async () => {
 
             engine = new CLIEngine({
                 cwd: getFixturePath(".."),
@@ -1155,7 +1156,7 @@ describe("CLIEngine", () => {
                 }
             });
 
-            const report = engine.executeOnFiles(["fixtures/files/.bar.js"]);
+            const report = await engine.executeOnFiles(["fixtures/files/.bar.js"]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].warningCount, 0);
@@ -1166,7 +1167,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should check .hidden files if they are unignored with an --ignore-pattern", () => {
+        it("should check .hidden files if they are unignored with an --ignore-pattern", async () => {
 
             engine = new CLIEngine({
                 cwd: getFixturePath("cli-engine"),
@@ -1178,7 +1179,7 @@ describe("CLIEngine", () => {
                 }
             });
 
-            const report = engine.executeOnFiles(["hidden/"]);
+            const report = await engine.executeOnFiles(["hidden/"]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].warningCount, 0);
@@ -1189,7 +1190,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should report zero messages when given a pattern with a .js and a .js2 file", () => {
+        it("should report zero messages when given a pattern with a .js and a .js2 file", async () => {
 
             engine = new CLIEngine({
                 extensions: [".js", ".js2"],
@@ -1197,7 +1198,7 @@ describe("CLIEngine", () => {
                 cwd: path.join(fixtureDir, "..")
             });
 
-            const report = engine.executeOnFiles(["fixtures/files/*.?s*"]);
+            const report = await engine.executeOnFiles(["fixtures/files/*.?s*"]);
 
             assert.strictEqual(report.results.length, 2);
             assert.strictEqual(report.results[0].messages.length, 0);
@@ -1206,13 +1207,13 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[1].suppressedMessages.length, 0);
         });
 
-        it("should return one error message when given a config with rules with options and severity level set to error", () => {
+        it("should return one error message when given a config with rules with options and severity level set to error", async () => {
 
             engine = new CLIEngine({
                 cwd: getFixturePath("configurations"),
                 configFile: getFixturePath("configurations", "quotes-error.json")
             });
-            const report = engine.executeOnFiles([getFixturePath("single-quoted.js")]);
+            const report = await engine.executeOnFiles([getFixturePath("single-quoted.js")]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].messages.length, 1);
@@ -1229,7 +1230,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should return 3 messages when given a config file and a directory of 3 valid files", () => {
+        it("should return 3 messages when given a config file and a directory of 3 valid files", async () => {
 
             engine = new CLIEngine({
                 cwd: path.join(fixtureDir, ".."),
@@ -1237,7 +1238,7 @@ describe("CLIEngine", () => {
             });
 
             const fixturePath = getFixturePath("formatters");
-            const report = engine.executeOnFiles([fixturePath]);
+            const report = await engine.executeOnFiles([fixturePath]);
 
             assert.strictEqual(report.errorCount, 0);
             assert.strictEqual(report.warningCount, 0);
@@ -1282,7 +1283,7 @@ describe("CLIEngine", () => {
         });
 
 
-        it("should return the total number of errors when given multiple files", () => {
+        it("should return the total number of errors when given multiple files", async () => {
 
             engine = new CLIEngine({
                 cwd: path.join(fixtureDir, ".."),
@@ -1290,7 +1291,7 @@ describe("CLIEngine", () => {
             });
 
             const fixturePath = getFixturePath("formatters");
-            const report = engine.executeOnFiles([fixturePath]);
+            const report = await engine.executeOnFiles([fixturePath]);
 
             assert.strictEqual(report.errorCount, 6);
             assert.strictEqual(report.warningCount, 0);
@@ -1324,35 +1325,35 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[4].fixableWarningCount, 0);
         });
 
-        it("should process when file is given by not specifying extensions", () => {
+        it("should process when file is given by not specifying extensions", async () => {
 
             engine = new CLIEngine({
                 ignore: false,
                 cwd: path.join(fixtureDir, "..")
             });
 
-            const report = engine.executeOnFiles(["fixtures/files/foo.js2"]);
+            const report = await engine.executeOnFiles(["fixtures/files/foo.js2"]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].messages.length, 0);
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should return zero messages when given a config with environment set to browser", () => {
+        it("should return zero messages when given a config with environment set to browser", async () => {
 
             engine = new CLIEngine({
                 cwd: path.join(fixtureDir, ".."),
                 configFile: getFixturePath("configurations", "env-browser.json")
             });
 
-            const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("globals-browser.js"))]);
+            const report = await engine.executeOnFiles([fs.realpathSync(getFixturePath("globals-browser.js"))]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].messages.length, 0);
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should return zero messages when given an option to set environment to browser", () => {
+        it("should return zero messages when given an option to set environment to browser", async () => {
 
             engine = new CLIEngine({
                 cwd: path.join(fixtureDir, ".."),
@@ -1363,28 +1364,28 @@ describe("CLIEngine", () => {
                 }
             });
 
-            const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("globals-browser.js"))]);
+            const report = await engine.executeOnFiles([fs.realpathSync(getFixturePath("globals-browser.js"))]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].messages.length, 0);
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should return zero messages when given a config with environment set to Node.js", () => {
+        it("should return zero messages when given a config with environment set to Node.js", async () => {
 
             engine = new CLIEngine({
                 cwd: path.join(fixtureDir, ".."),
                 configFile: getFixturePath("configurations", "env-node.json")
             });
 
-            const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("globals-node.js"))]);
+            const report = await engine.executeOnFiles([fs.realpathSync(getFixturePath("globals-node.js"))]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].messages.length, 0);
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should not return results from previous call when calling more than once", () => {
+        it("should not return results from previous call when calling more than once", async () => {
 
             engine = new CLIEngine({
                 cwd: path.join(fixtureDir, ".."),
@@ -1397,7 +1398,7 @@ describe("CLIEngine", () => {
             const failFilePath = fs.realpathSync(getFixturePath("missing-semicolon.js"));
             const passFilePath = fs.realpathSync(getFixturePath("passing.js"));
 
-            let report = engine.executeOnFiles([failFilePath]);
+            let report = await engine.executeOnFiles([failFilePath]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].filePath, failFilePath);
@@ -1406,7 +1407,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].messages[0].severity, 2);
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
 
-            report = engine.executeOnFiles([passFilePath]);
+            report = await engine.executeOnFiles([passFilePath]);
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].filePath, passFilePath);
             assert.strictEqual(report.results[0].messages.length, 0);
@@ -1414,42 +1415,42 @@ describe("CLIEngine", () => {
 
         });
 
-        it("should throw an error when given a directory with all eslint excluded files in the directory", () => {
+        it("should throw an error when given a directory with all eslint excluded files in the directory", async () => {
 
             engine = new CLIEngine({
                 ignorePath: getFixturePath(".eslintignore")
             });
 
-            assert.throws(() => {
-                engine.executeOnFiles([getFixturePath("./cli-engine/")]);
-            }, `All files matched by '${getFixturePath("./cli-engine/")}' are ignored.`);
+            await nodeAssert.rejects(async () => {
+                await engine.executeOnFiles([getFixturePath("./cli-engine/")]);
+            }, new RegExp(`All files matched by '${getFixturePath("./cli-engine/")}' are ignored.`, "u"));
         });
 
-        it("should throw an error when all given files are ignored", () => {
+        it("should throw an error when all given files are ignored", async () => {
 
             engine = new CLIEngine({
                 useEslintrc: false,
                 ignorePath: getFixturePath(".eslintignore")
             });
 
-            assert.throws(() => {
-                engine.executeOnFiles(["tests/fixtures/cli-engine/"]);
-            }, "All files matched by 'tests/fixtures/cli-engine/' are ignored.");
+            await nodeAssert.rejects(async () => {
+                await engine.executeOnFiles(["tests/fixtures/cli-engine/"]);
+            }, /All files matched by 'tests\/fixtures\/cli-engine\/' are ignored./u);
         });
 
-        it("should throw an error when all given files are ignored even with a `./` prefix", () => {
+        it("should throw an error when all given files are ignored even with a `./` prefix", async () => {
             engine = new CLIEngine({
                 useEslintrc: false,
                 ignorePath: getFixturePath(".eslintignore")
             });
 
-            assert.throws(() => {
-                engine.executeOnFiles(["./tests/fixtures/cli-engine/"]);
-            }, "All files matched by './tests/fixtures/cli-engine/' are ignored.");
+            await nodeAssert.rejects(async () => {
+                await engine.executeOnFiles(["./tests/fixtures/cli-engine/"]);
+            }, /All files matched by '.\/tests\/fixtures\/cli-engine\/' are ignored./u);
         });
 
         // https://github.com/eslint/eslint/issues/3788
-        it("should ignore one-level down node_modules when ignore file has 'node_modules/' in it", () => {
+        it("should ignore one-level down node_modules when ignore file has 'node_modules/' in it", async () => {
             engine = new CLIEngine({
                 ignorePath: getFixturePath("cli-engine", "nested_node_modules", ".eslintignore"),
                 useEslintrc: false,
@@ -1459,7 +1460,7 @@ describe("CLIEngine", () => {
                 cwd: getFixturePath("cli-engine", "nested_node_modules")
             });
 
-            const report = engine.executeOnFiles(["."]);
+            const report = await engine.executeOnFiles(["."]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].errorCount, 0);
@@ -1470,7 +1471,7 @@ describe("CLIEngine", () => {
         });
 
         // https://github.com/eslint/eslint/issues/3812
-        it("should ignore all files and throw an error when tests/fixtures/ is in ignore file", () => {
+        it("should ignore all files and throw an error when tests/fixtures/ is in ignore file", async () => {
             engine = new CLIEngine({
                 ignorePath: getFixturePath("cli-engine/.eslintignore2"),
                 useEslintrc: false,
@@ -1479,23 +1480,23 @@ describe("CLIEngine", () => {
                 }
             });
 
-            assert.throws(() => {
-                engine.executeOnFiles(["./tests/fixtures/cli-engine/"]);
-            }, "All files matched by './tests/fixtures/cli-engine/' are ignored.");
+            await nodeAssert.rejects(async () => {
+                await engine.executeOnFiles(["./tests/fixtures/cli-engine/"]);
+            }, /All files matched by '.\/tests\/fixtures\/cli-engine\/' are ignored./u);
         });
 
-        it("should throw an error when all given files are ignored via ignore-pattern", () => {
+        it("should throw an error when all given files are ignored via ignore-pattern", async () => {
             engine = new CLIEngine({
                 useEslintrc: false,
                 ignorePattern: "tests/fixtures/single-quoted.js"
             });
 
-            assert.throws(() => {
-                engine.executeOnFiles(["tests/fixtures/*-quoted.js"]);
-            }, "All files matched by 'tests/fixtures/*-quoted.js' are ignored.");
+            await nodeAssert.rejects(async () => {
+                await engine.executeOnFiles(["tests/fixtures/*-quoted.js"]);
+            }, /All files matched by 'tests\/fixtures\/\*-quoted.js' are ignored./u);
         });
 
-        it("should return a warning when an explicitly given file is ignored", () => {
+        it("should return a warning when an explicitly given file is ignored", async () => {
             engine = new CLIEngine({
                 ignorePath: getFixturePath(".eslintignore"),
                 cwd: getFixturePath()
@@ -1503,7 +1504,7 @@ describe("CLIEngine", () => {
 
             const filePath = getFixturePath("passing.js");
 
-            const report = engine.executeOnFiles([filePath]);
+            const report = await engine.executeOnFiles([filePath]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.errorCount, 0);
@@ -1522,7 +1523,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should return two messages when given a file in excluded files list while ignore is off", () => {
+        it("should return two messages when given a file in excluded files list while ignore is off", async () => {
 
             engine = new CLIEngine({
                 ignorePath: getFixturePath(".eslintignore"),
@@ -1534,7 +1535,7 @@ describe("CLIEngine", () => {
 
             const filePath = fs.realpathSync(getFixturePath("undef.js"));
 
-            const report = engine.executeOnFiles([filePath]);
+            const report = await engine.executeOnFiles([filePath]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].filePath, filePath);
@@ -1545,27 +1546,27 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should return zero messages when executing a file with a shebang", () => {
+        it("should return zero messages when executing a file with a shebang", async () => {
 
             engine = new CLIEngine({
                 ignore: false
             });
 
-            const report = engine.executeOnFiles([getFixturePath("shebang.js")]);
+            const report = await engine.executeOnFiles([getFixturePath("shebang.js")]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].messages.length, 0);
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should give a warning when loading a custom rule that doesn't exist", () => {
+        it("should give a warning when loading a custom rule that doesn't exist", async () => {
 
             engine = new CLIEngine({
                 ignore: false,
                 rulesPaths: [getFixturePath("rules", "dir1")],
                 configFile: getFixturePath("rules", "missing-rule.json")
             });
-            const report = engine.executeOnFiles([getFixturePath("rules", "test", "test-custom-rule.js")]);
+            const report = await engine.executeOnFiles([getFixturePath("rules", "test", "test-custom-rule.js")]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].messages.length, 1);
@@ -1575,7 +1576,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should throw an error when loading a bad custom rule", () => {
+        it("should throw an error when loading a bad custom rule", async () => {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -1584,12 +1585,12 @@ describe("CLIEngine", () => {
             });
 
 
-            assert.throws(() => {
-                engine.executeOnFiles([getFixturePath("rules", "test", "test-custom-rule.js")]);
+            await nodeAssert.rejects(async () => {
+                await engine.executeOnFiles([getFixturePath("rules", "test", "test-custom-rule.js")]);
             }, /Error while loading rule 'custom-rule'/u);
         });
 
-        it("should return one message when a custom rule matches a file", () => {
+        it("should return one message when a custom rule matches a file", async () => {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -1600,7 +1601,7 @@ describe("CLIEngine", () => {
 
             const filePath = fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"));
 
-            const report = engine.executeOnFiles([filePath]);
+            const report = await engine.executeOnFiles([filePath]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].filePath, filePath);
@@ -1610,7 +1611,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should load custom rule from the provided cwd", () => {
+        it("should load custom rule from the provided cwd", async () => {
             const cwd = path.resolve(getFixturePath("rules"));
 
             engine = new CLIEngine({
@@ -1622,7 +1623,7 @@ describe("CLIEngine", () => {
 
             const filePath = fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"));
 
-            const report = engine.executeOnFiles([filePath]);
+            const report = await engine.executeOnFiles([filePath]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].filePath, filePath);
@@ -1632,7 +1633,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should return messages when multiple custom rules match a file", () => {
+        it("should return messages when multiple custom rules match a file", async () => {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -1645,7 +1646,7 @@ describe("CLIEngine", () => {
 
             const filePath = fs.realpathSync(getFixturePath("rules", "test-multi-rulesdirs.js"));
 
-            const report = engine.executeOnFiles([filePath]);
+            const report = await engine.executeOnFiles([filePath]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].filePath, filePath);
@@ -1657,7 +1658,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should return zero messages when executing without useEslintrc flag", () => {
+        it("should return zero messages when executing without useEslintrc flag", async () => {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -1666,7 +1667,7 @@ describe("CLIEngine", () => {
 
             const filePath = fs.realpathSync(getFixturePath("missing-semicolon.js"));
 
-            const report = engine.executeOnFiles([filePath]);
+            const report = await engine.executeOnFiles([filePath]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].filePath, filePath);
@@ -1674,7 +1675,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should return zero messages when executing without useEslintrc flag in Node.js environment", () => {
+        it("should return zero messages when executing without useEslintrc flag in Node.js environment", async () => {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -1684,7 +1685,7 @@ describe("CLIEngine", () => {
 
             const filePath = fs.realpathSync(getFixturePath("process-exit.js"));
 
-            const report = engine.executeOnFiles([filePath]);
+            const report = await engine.executeOnFiles([filePath]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].filePath, filePath);
@@ -1692,7 +1693,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should return zero messages when executing with base-config flag set to false", () => {
+        it("should return zero messages when executing with base-config flag set to false", async () => {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -1702,7 +1703,7 @@ describe("CLIEngine", () => {
 
             const filePath = fs.realpathSync(getFixturePath("missing-semicolon.js"));
 
-            const report = engine.executeOnFiles([filePath]);
+            const report = await engine.executeOnFiles([filePath]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].filePath, filePath);
@@ -1710,7 +1711,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should return zero messages and ignore .eslintrc files when executing with no-eslintrc flag", () => {
+        it("should return zero messages and ignore .eslintrc files when executing with no-eslintrc flag", async () => {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -1720,7 +1721,7 @@ describe("CLIEngine", () => {
 
             const filePath = fs.realpathSync(getFixturePath("eslintrc", "quotes.js"));
 
-            const report = engine.executeOnFiles([filePath]);
+            const report = await engine.executeOnFiles([filePath]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].filePath, filePath);
@@ -1728,7 +1729,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should return zero messages and ignore package.json files when executing with no-eslintrc flag", () => {
+        it("should return zero messages and ignore package.json files when executing with no-eslintrc flag", async () => {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -1738,7 +1739,7 @@ describe("CLIEngine", () => {
 
             const filePath = fs.realpathSync(getFixturePath("packagejson", "quotes.js"));
 
-            const report = engine.executeOnFiles([filePath]);
+            const report = await engine.executeOnFiles([filePath]);
 
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.results[0].filePath, filePath);
@@ -1746,7 +1747,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should warn when deprecated rules are configured", () => {
+        it("should warn when deprecated rules are configured", async () => {
             engine = new CLIEngine({
                 cwd: originalDir,
                 useEslintrc: false,
@@ -1757,7 +1758,7 @@ describe("CLIEngine", () => {
                 }
             });
 
-            const report = engine.executeOnFiles(["lib/cli*.js"]);
+            const report = await engine.executeOnFiles(["lib/cli*.js"]);
 
             assert.sameDeepMembers(
                 report.usedDeprecatedRules,
@@ -1770,27 +1771,27 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should not warn when deprecated rules are not configured", () => {
+        it("should not warn when deprecated rules are not configured", async () => {
             engine = new CLIEngine({
                 cwd: originalDir,
                 useEslintrc: false,
                 rules: { indent: 1, "valid-jsdoc": 0, "require-jsdoc": 0 }
             });
 
-            const report = engine.executeOnFiles(["lib/cli*.js"]);
+            const report = await engine.executeOnFiles(["lib/cli*.js"]);
 
             assert.deepStrictEqual(report.usedDeprecatedRules, []);
             assert.strictEqual(report.results[0].suppressedMessages.length, 0);
         });
 
-        it("should warn when deprecated rules are found in a config", () => {
+        it("should warn when deprecated rules are found in a config", async () => {
             engine = new CLIEngine({
                 cwd: originalDir,
                 configFile: "tests/fixtures/cli-engine/deprecated-rule-config/.eslintrc.yml",
                 useEslintrc: false
             });
 
-            const report = engine.executeOnFiles(["lib/cli*.js"]);
+            const report = await engine.executeOnFiles(["lib/cli*.js"]);
 
             assert.deepStrictEqual(
                 report.usedDeprecatedRules,
@@ -1801,7 +1802,7 @@ describe("CLIEngine", () => {
 
         describe("Fix Mode", () => {
 
-            it("should return fixed text on multiple files when in fix mode", () => {
+            it("should return fixed text on multiple files when in fix mode", async () => {
 
                 /**
                  * Converts CRLF to LF in output.
@@ -1828,7 +1829,7 @@ describe("CLIEngine", () => {
                     }
                 });
 
-                const report = engine.executeOnFiles([path.resolve(fixtureDir, `${fixtureDir}/fixmode`)]);
+                const report = await engine.executeOnFiles([path.resolve(fixtureDir, `${fixtureDir}/fixmode`)]);
 
                 report.results.forEach(convertCRLF);
                 assert.deepStrictEqual(report.results, [
@@ -1906,7 +1907,7 @@ describe("CLIEngine", () => {
                 assert.strictEqual(report.fixableWarningCount, 0);
             });
 
-            it("should run autofix even if files are cached without autofix results", () => {
+            it("should run autofix even if files are cached without autofix results", async () => {
                 const baseOptions = {
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
@@ -1922,11 +1923,11 @@ describe("CLIEngine", () => {
                 engine = new CLIEngine(Object.assign({}, baseOptions, { cache: true, fix: false }));
 
                 // Do initial lint run and populate the cache file
-                engine.executeOnFiles([path.resolve(fixtureDir, `${fixtureDir}/fixmode`)]);
+                await engine.executeOnFiles([path.resolve(fixtureDir, `${fixtureDir}/fixmode`)]);
 
                 engine = new CLIEngine(Object.assign({}, baseOptions, { cache: true, fix: true }));
 
-                const report = engine.executeOnFiles([path.resolve(fixtureDir, `${fixtureDir}/fixmode`)]);
+                const report = await engine.executeOnFiles([path.resolve(fixtureDir, `${fixtureDir}/fixmode`)]);
 
                 assert.ok(report.results.some(result => result.output));
             });
@@ -1938,14 +1939,14 @@ describe("CLIEngine", () => {
         describe("configuration hierarchy", () => {
 
             // Default configuration - blank
-            it("should return zero messages when executing with no .eslintrc", () => {
+            it("should return zero messages when executing with no .eslintrc", async () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
+                const report = await engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 0);
@@ -1953,7 +1954,7 @@ describe("CLIEngine", () => {
             });
 
             // No default configuration rules - conf/environments.js (/*eslint-env node*/)
-            it("should return zero messages when executing with no .eslintrc in the Node.js environment", () => {
+            it("should return zero messages when executing with no .eslintrc in the Node.js environment", async () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
@@ -1961,7 +1962,7 @@ describe("CLIEngine", () => {
                     useEslintrc: false
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes-node.js`)]);
+                const report = await engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes-node.js`)]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 0);
@@ -1969,13 +1970,13 @@ describe("CLIEngine", () => {
             });
 
             // Project configuration - first level .eslintrc
-            it("should return zero messages when executing with .eslintrc in the Node.js environment", () => {
+            it("should return zero messages when executing with .eslintrc in the Node.js environment", async () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/process-exit.js`)]);
+                const report = await engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/process-exit.js`)]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 0);
@@ -1983,26 +1984,26 @@ describe("CLIEngine", () => {
             });
 
             // Project configuration - first level .eslintrc
-            it("should return zero messages when executing with .eslintrc in the Node.js environment", () => {
+            it("should return zero messages when executing with .eslintrc in the Node.js environment", async () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/process-exit.js`)]);
+                const report = await engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/process-exit.js`)]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 0);
             });
 
             // Project configuration - first level .eslintrc
-            it("should return one message when executing with .eslintrc", () => {
+            it("should return one message when executing with .eslintrc", async () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
+                const report = await engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 1);
@@ -2012,13 +2013,13 @@ describe("CLIEngine", () => {
             });
 
             // Project configuration - second level .eslintrc
-            it("should return one message when executing with local .eslintrc that overrides parent .eslintrc", () => {
+            it("should return one message when executing with local .eslintrc that overrides parent .eslintrc", async () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/subbroken/console-wrong-quotes.js`)]);
+                const report = await engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/subbroken/console-wrong-quotes.js`)]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 1);
@@ -2028,13 +2029,13 @@ describe("CLIEngine", () => {
             });
 
             // Project configuration - third level .eslintrc
-            it("should return one message when executing with local .eslintrc that overrides parent and grandparent .eslintrc", () => {
+            it("should return one message when executing with local .eslintrc that overrides parent and grandparent .eslintrc", async () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/subbroken/subsubbroken/console-wrong-quotes.js`)]);
+                const report = await engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/subbroken/subsubbroken/console-wrong-quotes.js`)]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 1);
@@ -2044,13 +2045,13 @@ describe("CLIEngine", () => {
             });
 
             // Project configuration - first level package.json
-            it("should return one message when executing with package.json", () => {
+            it("should return one message when executing with package.json", async () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/packagejson/subdir/wrong-quotes.js`)]);
+                const report = await engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/packagejson/subdir/wrong-quotes.js`)]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 1);
@@ -2060,13 +2061,13 @@ describe("CLIEngine", () => {
             });
 
             // Project configuration - second level package.json
-            it("should return zero messages when executing with local package.json that overrides parent package.json", () => {
+            it("should return zero messages when executing with local package.json that overrides parent package.json", async () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/packagejson/subdir/subsubdir/wrong-quotes.js`)]);
+                const report = await engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/packagejson/subdir/subsubdir/wrong-quotes.js`)]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 0);
@@ -2074,13 +2075,13 @@ describe("CLIEngine", () => {
             });
 
             // Project configuration - third level package.json
-            it("should return one message when executing with local package.json that overrides parent and grandparent package.json", () => {
+            it("should return one message when executing with local package.json that overrides parent and grandparent package.json", async () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/packagejson/subdir/subsubdir/subsubsubdir/wrong-quotes.js`)]);
+                const report = await engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/packagejson/subdir/subsubdir/subsubsubdir/wrong-quotes.js`)]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 1);
@@ -2090,13 +2091,13 @@ describe("CLIEngine", () => {
             });
 
             // Project configuration - .eslintrc overrides package.json in same directory
-            it("should return one message when executing with .eslintrc that overrides a package.json in the same directory", () => {
+            it("should return one message when executing with .eslintrc that overrides a package.json in the same directory", async () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/packagejson/wrong-quotes.js`)]);
+                const report = await engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/packagejson/wrong-quotes.js`)]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 1);
@@ -2106,14 +2107,14 @@ describe("CLIEngine", () => {
             });
 
             // Command line configuration - --config with first level .eslintrc
-            it("should return two messages when executing with config file that adds to local .eslintrc", () => {
+            it("should return two messages when executing with config file that adds to local .eslintrc", async () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     configFile: `${fixtureDir}/config-hierarchy/broken/add-conf.yaml`
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
+                const report = await engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 2);
@@ -2125,14 +2126,14 @@ describe("CLIEngine", () => {
             });
 
             // Command line configuration - --config with first level .eslintrc
-            it("should return no messages when executing with config file that overrides local .eslintrc", () => {
+            it("should return no messages when executing with config file that overrides local .eslintrc", async () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     configFile: `${fixtureDir}/config-hierarchy/broken/override-conf.yaml`
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
+                const report = await engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 0);
@@ -2140,14 +2141,14 @@ describe("CLIEngine", () => {
             });
 
             // Command line configuration - --config with second level .eslintrc
-            it("should return two messages when executing with config file that adds to local and parent .eslintrc", () => {
+            it("should return two messages when executing with config file that adds to local and parent .eslintrc", async () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     configFile: `${fixtureDir}/config-hierarchy/broken/add-conf.yaml`
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/subbroken/console-wrong-quotes.js`)]);
+                const report = await engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/subbroken/console-wrong-quotes.js`)]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 2);
@@ -2159,14 +2160,14 @@ describe("CLIEngine", () => {
             });
 
             // Command line configuration - --config with second level .eslintrc
-            it("should return one message when executing with config file that overrides local and parent .eslintrc", () => {
+            it("should return one message when executing with config file that overrides local and parent .eslintrc", async () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     configFile: getFixturePath("config-hierarchy/broken/override-conf.yaml")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/subbroken/console-wrong-quotes.js`)]);
+                const report = await engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/subbroken/console-wrong-quotes.js`)]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 1);
@@ -2176,14 +2177,14 @@ describe("CLIEngine", () => {
             });
 
             // Command line configuration - --config with first level .eslintrc
-            it("should return no messages when executing with config file that overrides local .eslintrc", () => {
+            it("should return no messages when executing with config file that overrides local .eslintrc", async () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     configFile: `${fixtureDir}/config-hierarchy/broken/override-conf.yaml`
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
+                const report = await engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 0);
@@ -2191,7 +2192,7 @@ describe("CLIEngine", () => {
             });
 
             // Command line configuration - --rule with --config and first level .eslintrc
-            it("should return one message when executing with command line rule and config file that overrides local .eslintrc", () => {
+            it("should return one message when executing with command line rule and config file that overrides local .eslintrc", async () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
@@ -2201,7 +2202,7 @@ describe("CLIEngine", () => {
                     }
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
+                const report = await engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 1);
@@ -2211,7 +2212,7 @@ describe("CLIEngine", () => {
             });
 
             // Command line configuration - --rule with --config and first level .eslintrc
-            it("should return one message when executing with command line rule and config file that overrides local .eslintrc", () => {
+            it("should return one message when executing with command line rule and config file that overrides local .eslintrc", async () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
@@ -2221,7 +2222,7 @@ describe("CLIEngine", () => {
                     }
                 });
 
-                const report = engine.executeOnFiles([getFixturePath("config-hierarchy/broken/console-wrong-quotes.js")]);
+                const report = await engine.executeOnFiles([getFixturePath("config-hierarchy/broken/console-wrong-quotes.js")]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 1);
@@ -2233,14 +2234,14 @@ describe("CLIEngine", () => {
         });
 
         describe("plugins", () => {
-            it("should return two messages when executing with config file that specifies a plugin", () => {
+            it("should return two messages when executing with config file that specifies a plugin", async () => {
                 engine = cliEngineWithPlugins({
                     cwd: path.join(fixtureDir, ".."),
                     configFile: getFixturePath("configurations", "plugins-with-prefix.json"),
                     useEslintrc: false
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test/test-custom-rule.js"))]);
+                const report = await engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test/test-custom-rule.js"))]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 2);
@@ -2248,14 +2249,14 @@ describe("CLIEngine", () => {
                 assert.strictEqual(report.results[0].suppressedMessages.length, 0);
             });
 
-            it("should return two messages when executing with config file that specifies a plugin with namespace", () => {
+            it("should return two messages when executing with config file that specifies a plugin with namespace", async () => {
                 engine = cliEngineWithPlugins({
                     cwd: path.join(fixtureDir, ".."),
                     configFile: getFixturePath("configurations", "plugins-with-prefix-and-namespace.json"),
                     useEslintrc: false
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
+                const report = await engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 2);
@@ -2263,14 +2264,14 @@ describe("CLIEngine", () => {
                 assert.strictEqual(report.results[0].suppressedMessages.length, 0);
             });
 
-            it("should return two messages when executing with config file that specifies a plugin without prefix", () => {
+            it("should return two messages when executing with config file that specifies a plugin without prefix", async () => {
                 engine = cliEngineWithPlugins({
                     cwd: path.join(fixtureDir, ".."),
                     configFile: getFixturePath("configurations", "plugins-without-prefix.json"),
                     useEslintrc: false
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
+                const report = await engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 2);
@@ -2278,14 +2279,14 @@ describe("CLIEngine", () => {
                 assert.strictEqual(report.results[0].suppressedMessages.length, 0);
             });
 
-            it("should return two messages when executing with config file that specifies a plugin without prefix and with namespace", () => {
+            it("should return two messages when executing with config file that specifies a plugin without prefix and with namespace", async () => {
                 engine = cliEngineWithPlugins({
                     cwd: path.join(fixtureDir, ".."),
                     configFile: getFixturePath("configurations", "plugins-without-prefix-with-namespace.json"),
                     useEslintrc: false
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
+                const report = await engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 2);
@@ -2293,7 +2294,7 @@ describe("CLIEngine", () => {
                 assert.strictEqual(report.results[0].suppressedMessages.length, 0);
             });
 
-            it("should return two messages when executing with cli option that specifies a plugin", () => {
+            it("should return two messages when executing with cli option that specifies a plugin", async () => {
                 engine = cliEngineWithPlugins({
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
@@ -2301,7 +2302,7 @@ describe("CLIEngine", () => {
                     rules: { "example/example-rule": 1 }
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
+                const report = await engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 2);
@@ -2309,7 +2310,7 @@ describe("CLIEngine", () => {
                 assert.strictEqual(report.results[0].suppressedMessages.length, 0);
             });
 
-            it("should return two messages when executing with cli option that specifies preloaded plugin", () => {
+            it("should return two messages when executing with cli option that specifies preloaded plugin", async () => {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
@@ -2325,7 +2326,7 @@ describe("CLIEngine", () => {
                     }
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
+                const report = await engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 2);
@@ -2333,7 +2334,7 @@ describe("CLIEngine", () => {
                 assert.strictEqual(report.results[0].suppressedMessages.length, 0);
             });
 
-            it("should load plugins from the `loadPluginsRelativeTo` directory, if specified", () => {
+            it("should load plugins from the `loadPluginsRelativeTo` directory, if specified", async () => {
                 engine = new CLIEngine({
                     resolvePluginsRelativeTo: getFixturePath("plugins"),
                     baseConfig: {
@@ -2343,7 +2344,7 @@ describe("CLIEngine", () => {
                     useEslintrc: false
                 });
 
-                const report = engine.executeOnText("foo");
+                const report = await engine.executeOnText("foo");
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 1);
@@ -2415,7 +2416,7 @@ describe("CLIEngine", () => {
                     deleteCacheDir();
                 });
 
-                it("should create the cache file inside the provided directory", () => {
+                it("should create the cache file inside the provided directory", async () => {
                     assert.isFalse(shell.test("-d", path.resolve("./tmp/.cacheFileDir/.cache_hashOfCurrentWorkingDirectory")), "the cache for eslint does not exist");
 
                     engine = new CLIEngine({
@@ -2434,7 +2435,7 @@ describe("CLIEngine", () => {
 
                     const file = getFixturePath("cache/src", "test-file.js");
 
-                    engine.executeOnFiles([file]);
+                    await engine.executeOnFiles([file]);
 
                     assert.isTrue(shell.test("-f", path.resolve(`./tmp/.cacheFileDir/.cache_${hash(process.cwd())}`)), "the cache for eslint was created");
 
@@ -2442,7 +2443,7 @@ describe("CLIEngine", () => {
                 });
             });
 
-            it("should create the cache file inside the provided directory using the cacheLocation option", () => {
+            it("should create the cache file inside the provided directory using the cacheLocation option", async () => {
                 assert.isFalse(shell.test("-d", path.resolve("./tmp/.cacheFileDir/.cache_hashOfCurrentWorkingDirectory")), "the cache for eslint does not exist");
 
                 engine = new CLIEngine({
@@ -2461,14 +2462,14 @@ describe("CLIEngine", () => {
 
                 const file = getFixturePath("cache/src", "test-file.js");
 
-                engine.executeOnFiles([file]);
+                await engine.executeOnFiles([file]);
 
                 assert.isTrue(shell.test("-f", path.resolve(`./tmp/.cacheFileDir/.cache_${hash(process.cwd())}`)), "the cache for eslint was created");
 
                 sinon.restore();
             });
 
-            it("should create the cache file inside cwd when no cacheLocation provided", () => {
+            it("should create the cache file inside cwd when no cacheLocation provided", async () => {
                 const cwd = path.resolve(getFixturePath("cli-engine"));
 
                 engine = new CLIEngine({
@@ -2484,12 +2485,12 @@ describe("CLIEngine", () => {
 
                 const file = getFixturePath("cli-engine", "console.js");
 
-                engine.executeOnFiles([file]);
+                await engine.executeOnFiles([file]);
 
                 assert.isTrue(shell.test("-f", path.resolve(cwd, ".eslintcache")), "the cache for eslint was created at provided cwd");
             });
 
-            it("should invalidate the cache if the configuration changed between executions", () => {
+            it("should invalidate the cache if the configuration changed between executions", async () => {
                 assert.isFalse(shell.test("-f", path.resolve(".eslintcache")), "the cache for eslint does not exist");
 
                 engine = new CLIEngine({
@@ -2511,7 +2512,7 @@ describe("CLIEngine", () => {
 
                 file = fs.realpathSync(file);
 
-                const result = engine.executeOnFiles([file]);
+                const result = await engine.executeOnFiles([file]);
 
                 assert.strictEqual(result.errorCount + result.warningCount, 0, "the file passed without errors or warnings");
                 assert.strictEqual(spy.getCall(0).args[0], file, "the module read the file because is considered changed");
@@ -2536,14 +2537,14 @@ describe("CLIEngine", () => {
                 // create a new spy
                 spy = sinon.spy(fs, "readFileSync");
 
-                const cachedResult = engine.executeOnFiles([file]);
+                const cachedResult = await engine.executeOnFiles([file]);
 
                 assert.strictEqual(spy.getCall(0).args[0], file, "the module read the file because is considered changed because the config changed");
                 assert.strictEqual(cachedResult.errorCount, 1, "since configuration changed the cache was not used an one error was reported");
                 assert.isTrue(shell.test("-f", path.resolve(".eslintcache")), "the cache for eslint was created");
             });
 
-            it("should remember the files from a previous run and do not operate on them if not changed", () => {
+            it("should remember the files from a previous run and do not operate on them if not changed", async () => {
 
                 assert.isFalse(shell.test("-f", path.resolve(".eslintcache")), "the cache for eslint does not exist");
 
@@ -2566,7 +2567,7 @@ describe("CLIEngine", () => {
 
                 file = fs.realpathSync(file);
 
-                const result = engine.executeOnFiles([file]);
+                const result = await engine.executeOnFiles([file]);
 
                 assert.strictEqual(spy.getCall(0).args[0], file, "the module read the file because is considered changed");
                 assert.isTrue(shell.test("-f", path.resolve(".eslintcache")), "the cache for eslint was created");
@@ -2590,7 +2591,7 @@ describe("CLIEngine", () => {
                 // create a new spy
                 spy = sinon.spy(fs, "readFileSync");
 
-                const cachedResult = engine.executeOnFiles([file]);
+                const cachedResult = await engine.executeOnFiles([file]);
 
                 assert.deepStrictEqual(result, cachedResult, "the result is the same regardless of using cache or not");
 
@@ -2598,7 +2599,7 @@ describe("CLIEngine", () => {
                 assert.isFalse(spy.calledWith(file), "the file was not loaded because it used the cache");
             });
 
-            it("should remember the files from a previous run and do not operate on then if not changed", () => {
+            it("should remember the files from a previous run and do not operate on then if not changed", async () => {
 
                 const cacheFile = getFixturePath(".eslintcache");
                 const cliEngineOptions = {
@@ -2623,19 +2624,19 @@ describe("CLIEngine", () => {
 
                 file = fs.realpathSync(file);
 
-                engine.executeOnFiles([file]);
+                await engine.executeOnFiles([file]);
 
                 assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint was created");
 
                 cliEngineOptions.cache = false;
                 engine = new CLIEngine(cliEngineOptions);
 
-                engine.executeOnFiles([file]);
+                await engine.executeOnFiles([file]);
 
                 assert.isFalse(shell.test("-f", cacheFile), "the cache for eslint was deleted since last run did not used the cache");
             });
 
-            it("should store in the cache a file that failed the test", () => {
+            it("should store in the cache a file that failed the test", async () => {
 
                 const cacheFile = getFixturePath(".eslintcache");
 
@@ -2658,7 +2659,7 @@ describe("CLIEngine", () => {
                 const badFile = fs.realpathSync(getFixturePath("cache/src", "fail-file.js"));
                 const goodFile = fs.realpathSync(getFixturePath("cache/src", "test-file.js"));
 
-                const result = engine.executeOnFiles([badFile, goodFile]);
+                const result = await engine.executeOnFiles([badFile, goodFile]);
 
                 assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint was created");
 
@@ -2669,12 +2670,12 @@ describe("CLIEngine", () => {
 
                 assert.isTrue(typeof cache.getKey(badFile) === "object", "the entry for the bad file is in the cache");
 
-                const cachedResult = engine.executeOnFiles([badFile, goodFile]);
+                const cachedResult = await engine.executeOnFiles([badFile, goodFile]);
 
                 assert.deepStrictEqual(result, cachedResult, "result is the same with or without cache");
             });
 
-            it("should not contain in the cache a file that was deleted", () => {
+            it("should not contain in the cache a file that was deleted", async () => {
 
                 const cacheFile = getFixturePath(".eslintcache");
 
@@ -2698,7 +2699,7 @@ describe("CLIEngine", () => {
                 const goodFile = fs.realpathSync(getFixturePath("cache/src", "test-file.js"));
                 const toBeDeletedFile = fs.realpathSync(getFixturePath("cache/src", "file-to-delete.js"));
 
-                engine.executeOnFiles([badFile, goodFile, toBeDeletedFile]);
+                await engine.executeOnFiles([badFile, goodFile, toBeDeletedFile]);
 
                 const fileCache = fCache.createFromFile(cacheFile);
                 let { cache } = fileCache;
@@ -2712,14 +2713,14 @@ describe("CLIEngine", () => {
                  * file-entry-cache@2.0.0 will remove from the cache deleted files
                  * even when they were not part of the array of files to be analyzed
                  */
-                engine.executeOnFiles([badFile, goodFile]);
+                await engine.executeOnFiles([badFile, goodFile]);
 
                 cache = JSON.parse(fs.readFileSync(cacheFile));
 
                 assert.isTrue(typeof cache[toBeDeletedFile] === "undefined", "the entry for the file to be deleted is not in the cache");
             });
 
-            it("should contain files that were not visited in the cache provided they still exist", () => {
+            it("should contain files that were not visited in the cache provided they still exist", async () => {
 
                 const cacheFile = getFixturePath(".eslintcache");
 
@@ -2743,7 +2744,7 @@ describe("CLIEngine", () => {
                 const goodFile = fs.realpathSync(getFixturePath("cache/src", "test-file.js"));
                 const testFile2 = fs.realpathSync(getFixturePath("cache/src", "test-file2.js"));
 
-                engine.executeOnFiles([badFile, goodFile, testFile2]);
+                await engine.executeOnFiles([badFile, goodFile, testFile2]);
 
                 let fileCache = fCache.createFromFile(cacheFile);
                 let { cache } = fileCache;
@@ -2755,7 +2756,7 @@ describe("CLIEngine", () => {
                  * previous version of file-entry-cache would remove the non visited
                  * entries. 2.0.0 version will keep them unless they don't exist
                  */
-                engine.executeOnFiles([badFile, goodFile]);
+                await engine.executeOnFiles([badFile, goodFile]);
 
                 fileCache = fCache.createFromFile(cacheFile);
                 cache = fileCache.cache;
@@ -2763,7 +2764,7 @@ describe("CLIEngine", () => {
                 assert.isTrue(typeof cache.getKey(testFile2) === "object", "the entry for the test-file2 is in the cache");
             });
 
-            it("should not delete cache when executing on text", () => {
+            it("should not delete cache when executing on text", async () => {
                 const cacheFile = getFixturePath(".eslintcache");
 
                 engine = new CLIEngine({
@@ -2779,12 +2780,12 @@ describe("CLIEngine", () => {
 
                 assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint exists");
 
-                engine.executeOnText("var foo = 'bar';");
+                await engine.executeOnText("var foo = 'bar';");
 
                 assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint still exists");
             });
 
-            it("should not delete cache when executing on text with a provided filename", () => {
+            it("should not delete cache when executing on text with a provided filename", async () => {
                 const cacheFile = getFixturePath(".eslintcache");
 
                 engine = new CLIEngine({
@@ -2800,12 +2801,12 @@ describe("CLIEngine", () => {
 
                 assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint exists");
 
-                engine.executeOnText("var bar = foo;", "fixtures/passing.js");
+                await engine.executeOnText("var bar = foo;", "fixtures/passing.js");
 
                 assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint still exists");
             });
 
-            it("should not delete cache when executing on files with --cache flag", () => {
+            it("should not delete cache when executing on files with --cache flag", async () => {
                 const cacheFile = getFixturePath(".eslintcache");
 
                 engine = new CLIEngine({
@@ -2824,12 +2825,12 @@ describe("CLIEngine", () => {
 
                 assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint exists");
 
-                engine.executeOnFiles([file]);
+                await engine.executeOnFiles([file]);
 
                 assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint still exists");
             });
 
-            it("should delete cache when executing on files without --cache flag", () => {
+            it("should delete cache when executing on files without --cache flag", async () => {
                 const cacheFile = getFixturePath(".eslintcache");
 
                 engine = new CLIEngine({
@@ -2847,13 +2848,13 @@ describe("CLIEngine", () => {
 
                 assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint exists");
 
-                engine.executeOnFiles([file]);
+                await engine.executeOnFiles([file]);
 
                 assert.isFalse(shell.test("-f", cacheFile), "the cache for eslint has been deleted");
             });
 
             describe("cacheFile", () => {
-                it("should use the specified cache file", () => {
+                it("should use the specified cache file", async () => {
                     const customCacheFile = path.resolve(".cache/custom-cache");
 
                     assert.isFalse(shell.test("-f", customCacheFile), "the cache for eslint does not exist");
@@ -2877,7 +2878,7 @@ describe("CLIEngine", () => {
                     const badFile = fs.realpathSync(getFixturePath("cache/src", "fail-file.js"));
                     const goodFile = fs.realpathSync(getFixturePath("cache/src", "test-file.js"));
 
-                    const result = engine.executeOnFiles([badFile, goodFile]);
+                    const result = await engine.executeOnFiles([badFile, goodFile]);
 
                     assert.isTrue(shell.test("-f", customCacheFile), "the cache for eslint was created");
 
@@ -2888,14 +2889,14 @@ describe("CLIEngine", () => {
 
                     assert.isTrue(typeof cache.getKey(badFile) === "object", "the entry for the bad file is in the cache");
 
-                    const cachedResult = engine.executeOnFiles([badFile, goodFile]);
+                    const cachedResult = await engine.executeOnFiles([badFile, goodFile]);
 
                     assert.deepStrictEqual(result, cachedResult, "result is the same with or without cache");
                 });
             });
 
             describe("cacheStrategy", () => {
-                it("should detect changes using a file's modification time when set to 'metadata'", () => {
+                it("should detect changes using a file's modification time when set to 'metadata'", async () => {
                     const cacheFile = getFixturePath(".eslintcache");
                     const badFile = getFixturePath("cache/src", "fail-file.js");
                     const goodFile = getFixturePath("cache/src", "test-file.js");
@@ -2917,7 +2918,7 @@ describe("CLIEngine", () => {
                         extensions: ["js"]
                     });
 
-                    engine.executeOnFiles([badFile, goodFile]);
+                    await engine.executeOnFiles([badFile, goodFile]);
 
                     let fileCache = fCache.createFromFile(cacheFile, false);
                     const entries = fileCache.normalizeEntries([badFile, goodFile]);
@@ -2933,7 +2934,7 @@ describe("CLIEngine", () => {
                     assert.isTrue(fileCache.getFileDescriptor(goodFile).changed, `the entry for ${goodFile} is changed`);
                 });
 
-                it("should not detect changes using a file's modification time when set to 'content'", () => {
+                it("should not detect changes using a file's modification time when set to 'content'", async () => {
                     const cacheFile = getFixturePath(".eslintcache");
                     const badFile = getFixturePath("cache/src", "fail-file.js");
                     const goodFile = getFixturePath("cache/src", "test-file.js");
@@ -2955,7 +2956,7 @@ describe("CLIEngine", () => {
                         extensions: ["js"]
                     });
 
-                    engine.executeOnFiles([badFile, goodFile]);
+                    await engine.executeOnFiles([badFile, goodFile]);
 
                     let fileCache = fCache.createFromFile(cacheFile, true);
                     let entries = fileCache.normalizeEntries([badFile, goodFile]);
@@ -2973,7 +2974,7 @@ describe("CLIEngine", () => {
                     });
                 });
 
-                it("should detect changes using a file's contents when set to 'content'", () => {
+                it("should detect changes using a file's contents when set to 'content'", async () => {
                     const cacheFile = getFixturePath(".eslintcache");
                     const badFile = getFixturePath("cache/src", "fail-file.js");
                     const goodFile = getFixturePath("cache/src", "test-file.js");
@@ -2998,7 +2999,7 @@ describe("CLIEngine", () => {
                         extensions: ["js"]
                     });
 
-                    engine.executeOnFiles([badFile, goodFileCopy]);
+                    await engine.executeOnFiles([badFile, goodFileCopy]);
 
                     let fileCache = fCache.createFromFile(cacheFile, true);
                     const entries = fileCache.normalizeEntries([badFile, goodFileCopy]);
@@ -3017,7 +3018,7 @@ describe("CLIEngine", () => {
         });
 
         describe("processors", () => {
-            it("should return two messages when executing with config file that specifies a processor", () => {
+            it("should return two messages when executing with config file that specifies a processor", async () => {
                 engine = cliEngineWithPlugins({
                     configFile: getFixturePath("configurations", "processors.json"),
                     useEslintrc: false,
@@ -3025,12 +3026,12 @@ describe("CLIEngine", () => {
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("processors", "test", "test-processor.txt"))]);
+                const report = await engine.executeOnFiles([fs.realpathSync(getFixturePath("processors", "test", "test-processor.txt"))]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 2);
             });
-            it("should return two messages when executing with config file that specifies preloaded processor", () => {
+            it("should return two messages when executing with config file that specifies preloaded processor", async () => {
                 engine = new CLIEngine({
                     useEslintrc: false,
                     plugins: ["test-processor"],
@@ -3057,12 +3058,12 @@ describe("CLIEngine", () => {
                     }
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("processors", "test", "test-processor.txt"))]);
+                const report = await engine.executeOnFiles([fs.realpathSync(getFixturePath("processors", "test", "test-processor.txt"))]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 2);
             });
-            it("should run processors when calling executeOnFiles with config file that specifies a processor", () => {
+            it("should run processors when calling executeOnFiles with config file that specifies a processor", async () => {
                 engine = cliEngineWithPlugins({
                     configFile: getFixturePath("configurations", "processors.json"),
                     useEslintrc: false,
@@ -3070,12 +3071,12 @@ describe("CLIEngine", () => {
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([getFixturePath("processors", "test", "test-processor.txt")]);
+                const report = await engine.executeOnFiles([getFixturePath("processors", "test", "test-processor.txt")]);
 
                 assert.strictEqual(report.results[0].messages[0].message, "'b' is defined but never used.");
                 assert.strictEqual(report.results[0].messages[0].ruleId, "post-processed");
             });
-            it("should run processors when calling executeOnFiles with config file that specifies preloaded processor", () => {
+            it("should run processors when calling executeOnFiles with config file that specifies preloaded processor", async () => {
                 engine = new CLIEngine({
                     useEslintrc: false,
                     plugins: ["test-processor"],
@@ -3103,12 +3104,12 @@ describe("CLIEngine", () => {
                     }
                 });
 
-                const report = engine.executeOnFiles([getFixturePath("processors", "test", "test-processor.txt")]);
+                const report = await engine.executeOnFiles([getFixturePath("processors", "test", "test-processor.txt")]);
 
                 assert.strictEqual(report.results[0].messages[0].message, "'b' is defined but never used.");
                 assert.strictEqual(report.results[0].messages[0].ruleId, "post-processed");
             });
-            it("should run processors when calling executeOnText with config file that specifies a processor", () => {
+            it("should run processors when calling executeOnText with config file that specifies a processor", async () => {
                 engine = cliEngineWithPlugins({
                     configFile: getFixturePath("configurations", "processors.json"),
                     useEslintrc: false,
@@ -3116,12 +3117,12 @@ describe("CLIEngine", () => {
                     ignore: false
                 });
 
-                const report = engine.executeOnText("function a() {console.log(\"Test\");}", "tests/fixtures/processors/test/test-processor.txt");
+                const report = await engine.executeOnText("function a() {console.log(\"Test\");}", "tests/fixtures/processors/test/test-processor.txt");
 
                 assert.strictEqual(report.results[0].messages[0].message, "'b' is defined but never used.");
                 assert.strictEqual(report.results[0].messages[0].ruleId, "post-processed");
             });
-            it("should run processors when calling executeOnText with config file that specifies preloaded processor", () => {
+            it("should run processors when calling executeOnText with config file that specifies preloaded processor", async () => {
                 engine = new CLIEngine({
                     useEslintrc: false,
                     plugins: ["test-processor"],
@@ -3149,7 +3150,7 @@ describe("CLIEngine", () => {
                     }
                 });
 
-                const report = engine.executeOnText("function a() {console.log(\"Test\");}", "tests/fixtures/processors/test/test-processor.txt");
+                const report = await engine.executeOnText("function a() {console.log(\"Test\");}", "tests/fixtures/processors/test/test-processor.txt");
 
                 assert.strictEqual(report.results[0].messages[0].message, "'b' is defined but never used.");
                 assert.strictEqual(report.results[0].messages[0].ruleId, "post-processed");
@@ -3175,7 +3176,7 @@ describe("CLIEngine", () => {
                 });
 
 
-                it("should run in autofix mode when using a processor that supports autofixing", () => {
+                it("should run in autofix mode when using a processor that supports autofixing", async () => {
                     engine = new CLIEngine({
                         useEslintrc: false,
                         plugins: ["test-processor"],
@@ -3195,13 +3196,13 @@ describe("CLIEngine", () => {
                         }
                     });
 
-                    const report = engine.executeOnText("<script>foo</script>", "foo.html");
+                    const report = await engine.executeOnText("<script>foo</script>", "foo.html");
 
                     assert.strictEqual(report.results[0].messages.length, 0);
                     assert.strictEqual(report.results[0].output, "<script>foo;</script>");
                 });
 
-                it("should not run in autofix mode when using a processor that does not support autofixing", () => {
+                it("should not run in autofix mode when using a processor that does not support autofixing", async () => {
                     engine = new CLIEngine({
                         useEslintrc: false,
                         plugins: ["test-processor"],
@@ -3221,13 +3222,13 @@ describe("CLIEngine", () => {
                         }
                     });
 
-                    const report = engine.executeOnText("<script>foo</script>", "foo.html");
+                    const report = await engine.executeOnText("<script>foo</script>", "foo.html");
 
                     assert.strictEqual(report.results[0].messages.length, 1);
                     assert.isFalse(Object.prototype.hasOwnProperty.call(report.results[0], "output"));
                 });
 
-                it("should not run in autofix mode when `fix: true` is not provided, even if the processor supports autofixing", () => {
+                it("should not run in autofix mode when `fix: true` is not provided, even if the processor supports autofixing", async () => {
                     engine = new CLIEngine({
                         useEslintrc: false,
                         plugins: ["test-processor"],
@@ -3246,7 +3247,7 @@ describe("CLIEngine", () => {
                         }
                     });
 
-                    const report = engine.executeOnText("<script>foo</script>", "foo.html");
+                    const report = await engine.executeOnText("<script>foo</script>", "foo.html");
 
                     assert.strictEqual(report.results[0].messages.length, 1);
                     assert.isFalse(Object.prototype.hasOwnProperty.call(report.results[0], "output"));
@@ -3262,34 +3263,34 @@ describe("CLIEngine", () => {
                 });
             });
 
-            it("one file", () => {
-                assert.throws(() => {
-                    engine.executeOnFiles(["non-exist.js"]);
-                }, "No files matching 'non-exist.js' were found.");
+            it("one file", async () => {
+                await nodeAssert.rejects(async () => {
+                    await engine.executeOnFiles(["non-exist.js"]);
+                }, /No files matching 'non-exist.js' were found./u);
             });
 
-            it("should throw if the directory exists and is empty", () => {
-                assert.throws(() => {
-                    engine.executeOnFiles(["empty"]);
-                }, "No files matching 'empty' were found.");
+            it("should throw if the directory exists and is empty", async () => {
+                await nodeAssert.rejects(async () => {
+                    await engine.executeOnFiles(["empty"]);
+                }, /No files matching 'empty' were found./u);
             });
 
-            it("one glob pattern", () => {
-                assert.throws(() => {
-                    engine.executeOnFiles(["non-exist/**/*.js"]);
-                }, "No files matching 'non-exist/**/*.js' were found.");
+            it("one glob pattern", async () => {
+                await nodeAssert.rejects(async () => {
+                    await engine.executeOnFiles(["non-exist/**/*.js"]);
+                }, /No files matching 'non-exist\/\*\*\/\*\.js' were found/u);
             });
 
-            it("two files", () => {
-                assert.throws(() => {
-                    engine.executeOnFiles(["aaa.js", "bbb.js"]);
-                }, "No files matching 'aaa.js' were found.");
+            it("two files", async () => {
+                await nodeAssert.rejects(async () => {
+                    await engine.executeOnFiles(["aaa.js", "bbb.js"]);
+                }, /No files matching 'aaa\.js' were found/u);
             });
 
-            it("a mix of an existing file and a non-existing file", () => {
-                assert.throws(() => {
-                    engine.executeOnFiles(["console.js", "non-exist.js"]);
-                }, "No files matching 'non-exist.js' were found.");
+            it("a mix of an existing file and a non-existing file", async () => {
+                await nodeAssert.rejects(async () => {
+                    await engine.executeOnFiles(["console.js", "non-exist.js"]);
+                }, /No files matching 'non-exist\.js' were found/u);
             });
         });
 
@@ -3301,8 +3302,8 @@ describe("CLIEngine", () => {
                 });
             });
 
-            it("should recognize dotfiles", () => {
-                const ret = engine.executeOnFiles([".test-target.js"]);
+            it("should recognize dotfiles", async () => {
+                const ret = await engine.executeOnFiles([".test-target.js"]);
 
                 assert.strictEqual(ret.results.length, 1);
                 assert.strictEqual(ret.results[0].messages.length, 1);
@@ -3340,8 +3341,8 @@ describe("CLIEngine", () => {
 
             afterEach(cleanup);
 
-            it("should not report 'no-console' error.", () => {
-                const { results } = engine.executeOnFiles("a.js");
+            it("should not report 'no-console' error.", async () => {
+                const { results } = await engine.executeOnFiles("a.js");
 
                 assert.strictEqual(results.length, 1);
                 assert.deepStrictEqual(results[0].messages, []);
@@ -3386,9 +3387,9 @@ describe("CLIEngine", () => {
 
             afterEach(cleanup);
 
-            it("should throw fatal error.", () => {
-                assert.throws(() => {
-                    engine.executeOnFiles("a.js");
+            it("should throw fatal error.", async () => {
+                await nodeAssert.rejects(async () => {
+                    await engine.executeOnFiles("a.js");
                 }, /invalid-option/u);
             });
         });
@@ -3439,8 +3440,8 @@ describe("CLIEngine", () => {
             afterEach(cleanup);
 
 
-            it("should not crash.", () => {
-                const { results } = engine.executeOnFiles("a.js");
+            it("should not crash.", async () => {
+                const { results } = await engine.executeOnFiles("a.js");
 
                 assert.strictEqual(results.length, 1);
                 assert.deepStrictEqual(results[0].messages, []);
@@ -3514,7 +3515,7 @@ describe("CLIEngine", () => {
                 await teardown.prepare();
                 engine = new CLIEngine({ cwd: teardown.getPath() });
 
-                const { results } = engine.executeOnFiles(["test.md"]);
+                const { results } = await engine.executeOnFiles(["test.md"]);
 
                 assert.strictEqual(results.length, 1);
                 assert.strictEqual(results[0].messages.length, 1);
@@ -3543,7 +3544,7 @@ describe("CLIEngine", () => {
                     fix: true
                 });
 
-                const { results } = engine.executeOnFiles(["test.md"]);
+                const { results } = await engine.executeOnFiles(["test.md"]);
 
                 assert.strictEqual(results.length, 1);
                 assert.strictEqual(results[0].messages.length, 0);
@@ -3583,7 +3584,7 @@ describe("CLIEngine", () => {
                     extensions: ["js", "html"]
                 });
 
-                const { results } = engine.executeOnFiles(["test.md"]);
+                const { results } = await engine.executeOnFiles(["test.md"]);
 
                 assert.strictEqual(results.length, 1);
                 assert.strictEqual(results[0].messages.length, 2);
@@ -3614,7 +3615,7 @@ describe("CLIEngine", () => {
                     fix: true
                 });
 
-                const { results } = engine.executeOnFiles(["test.md"]);
+                const { results } = await engine.executeOnFiles(["test.md"]);
 
                 assert.strictEqual(results.length, 1);
                 assert.strictEqual(results[0].messages.length, 0);
@@ -3662,7 +3663,7 @@ describe("CLIEngine", () => {
                     fix: true
                 });
 
-                const { results } = engine.executeOnFiles(["test.md"]);
+                const { results } = await engine.executeOnFiles(["test.md"]);
 
                 assert.strictEqual(results.length, 1);
                 assert.strictEqual(results[0].messages.length, 1);
@@ -3724,7 +3725,7 @@ describe("CLIEngine", () => {
                     extensions: ["js", "html"]
                 });
 
-                const { results } = engine.executeOnFiles(["test.md"]);
+                const { results } = await engine.executeOnFiles(["test.md"]);
 
                 assert.strictEqual(results.length, 1);
                 assert.strictEqual(results[0].messages.length, 2);
@@ -3772,7 +3773,7 @@ describe("CLIEngine", () => {
                     extensions: ["js", "html"]
                 });
 
-                const { results } = engine.executeOnFiles(["test.md"]);
+                const { results } = await engine.executeOnFiles(["test.md"]);
 
                 assert.strictEqual(results.length, 1);
                 assert.strictEqual(results[0].messages.length, 3);
@@ -3804,8 +3805,8 @@ describe("CLIEngine", () => {
                     cwd: teardown.getPath()
                 });
 
-                assert.throws(() => {
-                    engine.executeOnFiles(["test.md"]);
+                await nodeAssert.rejects(async () => {
+                    await engine.executeOnFiles(["test.md"]);
                 }, /ESLint configuration of processor in '\.eslintrc\.json' is invalid: 'markdown\/unknown' was not found\./u);
             });
 
@@ -3838,7 +3839,7 @@ describe("CLIEngine", () => {
                     cwd: teardown.getPath()
                 });
 
-                const { results } = engine.executeOnFiles(["test.md"]);
+                const { results } = await engine.executeOnFiles(["test.md"]);
 
                 assert.strictEqual(results.length, 1);
                 assert.strictEqual(results[0].messages.length, 2);
@@ -3857,9 +3858,9 @@ describe("CLIEngine", () => {
                 engine = new CLIEngine({ cwd });
             });
 
-            it("should throw an error with a message template when 'extends' property has a non-existence JavaScript config.", () => {
+            it("should throw an error with a message template when 'extends' property has a non-existence JavaScript config.", async () => {
                 try {
-                    engine.executeOnText("test", "extends-js/test.js");
+                    await engine.executeOnText("test", "extends-js/test.js");
                 } catch (err) {
                     assert.strictEqual(err.messageTemplate, "extend-config-missing");
                     assert.deepStrictEqual(err.messageData, {
@@ -3871,9 +3872,9 @@ describe("CLIEngine", () => {
                 assert.fail("Expected to throw an error");
             });
 
-            it("should throw an error with a message template when 'extends' property has a non-existence plugin config.", () => {
+            it("should throw an error with a message template when 'extends' property has a non-existence plugin config.", async () => {
                 try {
-                    engine.executeOnText("test", "extends-plugin/test.js");
+                    await engine.executeOnText("test", "extends-plugin/test.js");
                 } catch (err) {
                     assert.strictEqual(err.code, "MODULE_NOT_FOUND");
                     assert.strictEqual(err.messageTemplate, "plugin-missing");
@@ -3887,9 +3888,9 @@ describe("CLIEngine", () => {
                 assert.fail("Expected to throw an error");
             });
 
-            it("should throw an error with a message template when 'plugins' property has a non-existence plugin.", () => {
+            it("should throw an error with a message template when 'plugins' property has a non-existence plugin.", async () => {
                 try {
-                    engine.executeOnText("test", "plugins/test.js");
+                    await engine.executeOnText("test", "plugins/test.js");
                 } catch (err) {
                     assert.strictEqual(err.code, "MODULE_NOT_FOUND");
                     assert.strictEqual(err.messageTemplate, "plugin-missing");
@@ -3903,9 +3904,9 @@ describe("CLIEngine", () => {
                 assert.fail("Expected to throw an error");
             });
 
-            it("should throw an error with no message template when a JavaScript config threw a 'MODULE_NOT_FOUND' error.", () => {
+            it("should throw an error with no message template when a JavaScript config threw a 'MODULE_NOT_FOUND' error.", async () => {
                 try {
-                    engine.executeOnText("test", "throw-in-config-itself/test.js");
+                    await engine.executeOnText("test", "throw-in-config-itself/test.js");
                 } catch (err) {
                     assert.strictEqual(err.code, "MODULE_NOT_FOUND");
                     assert.strictEqual(err.messageTemplate, void 0);
@@ -3914,9 +3915,9 @@ describe("CLIEngine", () => {
                 assert.fail("Expected to throw an error");
             });
 
-            it("should throw an error with no message template when 'extends' property has a JavaScript config that throws a 'MODULE_NOT_FOUND' error.", () => {
+            it("should throw an error with no message template when 'extends' property has a JavaScript config that throws a 'MODULE_NOT_FOUND' error.", async () => {
                 try {
-                    engine.executeOnText("test", "throw-in-extends-js/test.js");
+                    await engine.executeOnText("test", "throw-in-extends-js/test.js");
                 } catch (err) {
                     assert.strictEqual(err.code, "MODULE_NOT_FOUND");
                     assert.strictEqual(err.messageTemplate, void 0);
@@ -3925,9 +3926,9 @@ describe("CLIEngine", () => {
                 assert.fail("Expected to throw an error");
             });
 
-            it("should throw an error with no message template when 'extends' property has a plugin config that throws a 'MODULE_NOT_FOUND' error.", () => {
+            it("should throw an error with no message template when 'extends' property has a plugin config that throws a 'MODULE_NOT_FOUND' error.", async () => {
                 try {
-                    engine.executeOnText("test", "throw-in-extends-plugin/test.js");
+                    await engine.executeOnText("test", "throw-in-extends-plugin/test.js");
                 } catch (err) {
                     assert.strictEqual(err.code, "MODULE_NOT_FOUND");
                     assert.strictEqual(err.messageTemplate, void 0);
@@ -3936,9 +3937,9 @@ describe("CLIEngine", () => {
                 assert.fail("Expected to throw an error");
             });
 
-            it("should throw an error with no message template when 'plugins' property has a plugin config that throws a 'MODULE_NOT_FOUND' error.", () => {
+            it("should throw an error with no message template when 'plugins' property has a plugin config that throws a 'MODULE_NOT_FOUND' error.", async () => {
                 try {
-                    engine.executeOnText("test", "throw-in-plugins/test.js");
+                    await engine.executeOnText("test", "throw-in-plugins/test.js");
                 } catch (err) {
                     assert.strictEqual(err.code, "MODULE_NOT_FOUND");
                     assert.strictEqual(err.messageTemplate, void 0);
@@ -3974,13 +3975,13 @@ describe("CLIEngine", () => {
             afterEach(cleanup);
 
 
-            it("should use the configured rules which are defined by '--rulesdir' option.", () => {
+            it("should use the configured rules which are defined by '--rulesdir' option.", async () => {
 
                 engine = new CLIEngine({
                     cwd: getPath(),
                     rulePaths: ["internal-rules"]
                 });
-                const report = engine.executeOnFiles(["test.js"]);
+                const report = await engine.executeOnFiles(["test.js"]);
 
                 assert.strictEqual(report.results.length, 1);
                 assert.strictEqual(report.results[0].messages.length, 1);
@@ -4018,7 +4019,7 @@ describe("CLIEngine", () => {
                 await teardown.prepare();
                 cleanup = teardown.cleanup;
 
-                const { results } = engine.executeOnFiles(["[ab].js"]);
+                const { results } = await engine.executeOnFiles(["[ab].js"]);
                 const filenames = results.map(r => path.basename(r.filePath));
 
                 assert.deepStrictEqual(filenames, ["[ab].js"]);
@@ -4041,7 +4042,7 @@ describe("CLIEngine", () => {
                 await teardown.prepare();
                 cleanup = teardown.cleanup;
 
-                const { results } = engine.executeOnFiles(["[ab].js"]);
+                const { results } = await engine.executeOnFiles(["[ab].js"]);
                 const filenames = results.map(r => path.basename(r.filePath));
 
                 assert.deepStrictEqual(filenames, ["a.js", "b.js"]);
@@ -4073,7 +4074,7 @@ describe("CLIEngine", () => {
                 cleanup = teardown.cleanup;
                 engine = new CLIEngine({ cwd: teardown.getPath() });
 
-                const { results } = engine.executeOnFiles(["test.js"]);
+                const { results } = await engine.executeOnFiles(["test.js"]);
                 const messages = results[0].messages;
 
                 assert.strictEqual(messages.length, 1);
@@ -4096,7 +4097,7 @@ describe("CLIEngine", () => {
                 cleanup = teardown.cleanup;
                 engine = new CLIEngine({ cwd: teardown.getPath() });
 
-                const { results } = engine.executeOnFiles(["test.js"]);
+                const { results } = await engine.executeOnFiles(["test.js"]);
                 const messages = results[0].messages;
 
                 assert.strictEqual(messages.length, 1);
@@ -4129,7 +4130,7 @@ describe("CLIEngine", () => {
                 cleanup = teardown.cleanup;
                 engine = new CLIEngine({ cwd: teardown.getPath() });
 
-                const { results } = engine.executeOnFiles(["test.js"]);
+                const { results } = await engine.executeOnFiles(["test.js"]);
                 const messages = results[0].messages;
 
                 assert.strictEqual(messages.length, 1);
@@ -4156,7 +4157,7 @@ describe("CLIEngine", () => {
                         reportUnusedDisableDirectives: "off"
                     });
 
-                    const { results } = engine.executeOnFiles(["test.js"]);
+                    const { results } = await engine.executeOnFiles(["test.js"]);
                     const messages = results[0].messages;
 
                     assert.strictEqual(messages.length, 0);
@@ -4180,7 +4181,7 @@ describe("CLIEngine", () => {
                         reportUnusedDisableDirectives: "error"
                     });
 
-                    const { results } = engine.executeOnFiles(["test.js"]);
+                    const { results } = await engine.executeOnFiles(["test.js"]);
                     const messages = results[0].messages;
 
                     assert.strictEqual(messages.length, 1);
@@ -4214,10 +4215,10 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("should not throw.", () => {
+            it("should not throw.", async () => {
                 engine = new CLIEngine({ cwd: getPath() });
 
-                const { results } = engine.executeOnFiles(["test.js"]);
+                const { results } = await engine.executeOnFiles(["test.js"]);
                 const messages = results[0].messages;
 
                 assert.strictEqual(messages.length, 1);
@@ -4260,7 +4261,7 @@ describe("CLIEngine", () => {
                 engine = new CLIEngine({ cwd: teardown.getPath() });
 
                 // Don't throw "failed to load config file" error.
-                engine.executeOnFiles(".");
+                await engine.executeOnFiles(".");
             });
 
             it("'executeOnFiles(\".\")' should not ignore '.' even if 'ignorePatterns' contains it.", async () => {
@@ -4279,7 +4280,7 @@ describe("CLIEngine", () => {
 
 
                 // Don't throw "file not found" error.
-                engine.executeOnFiles(".");
+                await engine.executeOnFiles(".");
             });
 
             it("'executeOnFiles(\"subdir\")' should not ignore './subdir' even if 'ignorePatterns' contains it.", async () => {
@@ -4297,14 +4298,14 @@ describe("CLIEngine", () => {
                 engine = new CLIEngine({ cwd: teardown.getPath() });
 
                 // Don't throw "file not found" error.
-                engine.executeOnFiles("subdir");
+                await engine.executeOnFiles("subdir");
             });
         });
     });
 
     describe("getConfigForFile", () => {
 
-        it("should return the info from Config#getConfig when called", () => {
+        it("should return the info from Config#getConfig when called", async () => {
             const options = {
                 configFile: getFixturePath("configurations", "quotes-error.json")
             };
@@ -4321,7 +4322,7 @@ describe("CLIEngine", () => {
         });
 
 
-        it("should return the config when run from within a subdir", () => {
+        it("should return the config when run from within a subdir", async () => {
             const options = {
                 cwd: getFixturePath("config-hierarchy", "root-true", "parent", "root", "subdir")
             };
@@ -4337,7 +4338,7 @@ describe("CLIEngine", () => {
             assert.deepStrictEqual(actualConfig, expectedConfig);
         });
 
-        it("should throw an error if a directory path was given.", () => {
+        it("should throw an error if a directory path was given.", async () => {
             const engine = new CLIEngine();
 
             try {
@@ -4351,7 +4352,7 @@ describe("CLIEngine", () => {
     });
 
     describe("isPathIgnored", () => {
-        it("should check if the given path is ignored", () => {
+        it("should check if the given path is ignored", async () => {
             const engine = new CLIEngine({
                 ignorePath: getFixturePath(".eslintignore2"),
                 cwd: getFixturePath()
@@ -4361,7 +4362,7 @@ describe("CLIEngine", () => {
             assert.isFalse(engine.isPathIgnored("passing.js"));
         });
 
-        it("should return false if ignoring is disabled", () => {
+        it("should return false if ignoring is disabled", async () => {
             const engine = new CLIEngine({
                 ignore: false,
                 ignorePath: getFixturePath(".eslintignore2"),
@@ -4372,7 +4373,7 @@ describe("CLIEngine", () => {
         });
 
         // https://github.com/eslint/eslint/issues/5547
-        it("should return true for default ignores even if ignoring is disabled", () => {
+        it("should return true for default ignores even if ignoring is disabled", async () => {
             const engine = new CLIEngine({
                 ignore: false,
                 cwd: getFixturePath("cli-engine")
@@ -4382,7 +4383,7 @@ describe("CLIEngine", () => {
         });
 
         describe("about the default ignore patterns", () => {
-            it("should always apply defaultPatterns if ignore option is true", () => {
+            it("should always apply defaultPatterns if ignore option is true", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ cwd });
 
@@ -4390,7 +4391,7 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored(getFixturePath("ignored-paths", "subdir/node_modules/package/file.js")));
             });
 
-            it("should still apply defaultPatterns if ignore option is is false", () => {
+            it("should still apply defaultPatterns if ignore option is is false", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ ignore: false, cwd });
 
@@ -4398,21 +4399,21 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored(getFixturePath("ignored-paths", "subdir/node_modules/package/file.js")));
             });
 
-            it("should allow subfolders of defaultPatterns to be unignored by ignorePattern", () => {
+            it("should allow subfolders of defaultPatterns to be unignored by ignorePattern", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ cwd, ignorePattern: "!/node_modules/package" });
 
                 assert(!engine.isPathIgnored(getFixturePath("ignored-paths", "node_modules", "package", "file.js")));
             });
 
-            it("should allow subfolders of defaultPatterns to be unignored by ignorePath", () => {
+            it("should allow subfolders of defaultPatterns to be unignored by ignorePath", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ cwd, ignorePath: getFixturePath("ignored-paths", ".eslintignoreWithUnignoredDefaults") });
 
                 assert(!engine.isPathIgnored(getFixturePath("ignored-paths", "node_modules", "package", "file.js")));
             });
 
-            it("should ignore dotfiles", () => {
+            it("should ignore dotfiles", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ cwd });
 
@@ -4420,7 +4421,7 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored(getFixturePath("ignored-paths", "foo/.bar")));
             });
 
-            it("should ignore directories beginning with a dot", () => {
+            it("should ignore directories beginning with a dot", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ cwd });
 
@@ -4428,7 +4429,7 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored(getFixturePath("ignored-paths", "foo/.bar/baz")));
             });
 
-            it("should still ignore dotfiles when ignore option disabled", () => {
+            it("should still ignore dotfiles when ignore option disabled", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ ignore: false, cwd });
 
@@ -4436,7 +4437,7 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored(getFixturePath("ignored-paths", "foo/.bar")));
             });
 
-            it("should still ignore directories beginning with a dot when ignore option disabled", () => {
+            it("should still ignore directories beginning with a dot when ignore option disabled", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ ignore: false, cwd });
 
@@ -4444,14 +4445,14 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored(getFixturePath("ignored-paths", "foo/.bar/baz")));
             });
 
-            it("should not ignore absolute paths containing '..'", () => {
+            it("should not ignore absolute paths containing '..'", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ cwd });
 
                 assert(!engine.isPathIgnored(`${getFixturePath("ignored-paths", "foo")}/../unignored.js`));
             });
 
-            it("should ignore /node_modules/ relative to .eslintignore when loaded", () => {
+            it("should ignore /node_modules/ relative to .eslintignore when loaded", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ ignorePath: getFixturePath("ignored-paths", ".eslintignore"), cwd });
 
@@ -4459,7 +4460,7 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored(getFixturePath("ignored-paths", "foo", "node_modules", "existing.js")));
             });
 
-            it("should ignore /node_modules/ relative to cwd without an .eslintignore", () => {
+            it("should ignore /node_modules/ relative to cwd without an .eslintignore", async () => {
                 const cwd = getFixturePath("ignored-paths", "no-ignore-file");
                 const engine = new CLIEngine({ cwd });
 
@@ -4469,7 +4470,7 @@ describe("CLIEngine", () => {
         });
 
         describe("with no .eslintignore file", () => {
-            it("should not travel to parent directories to find .eslintignore when it's missing and cwd is provided", () => {
+            it("should not travel to parent directories to find .eslintignore when it's missing and cwd is provided", async () => {
                 const cwd = getFixturePath("ignored-paths", "configurations");
                 const engine = new CLIEngine({ cwd });
 
@@ -4478,7 +4479,7 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored("node_modules/foo.js"));
             });
 
-            it("should return false for files outside of the cwd (with no ignore file provided)", () => {
+            it("should return false for files outside of the cwd (with no ignore file provided)", async () => {
 
                 // Default ignore patterns should not inadvertently ignore files in parent directories
                 const engine = new CLIEngine({ cwd: getFixturePath("ignored-paths", "no-ignore-file") });
@@ -4488,7 +4489,7 @@ describe("CLIEngine", () => {
         });
 
         describe("with .eslintignore file or package.json file", () => {
-            it("should load .eslintignore from cwd when explicitly passed", () => {
+            it("should load .eslintignore from cwd when explicitly passed", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ cwd });
 
@@ -4496,7 +4497,7 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored("sampleignorepattern"));
             });
 
-            it("should use package.json's eslintIgnore files if no specified .eslintignore file", () => {
+            it("should use package.json's eslintIgnore files if no specified .eslintignore file", async () => {
                 const cwd = getFixturePath("ignored-paths", "package-json-ignore");
                 const engine = new CLIEngine({ cwd });
 
@@ -4504,7 +4505,7 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored("world.js"));
             });
 
-            it("should use correct message template if failed to parse package.json", () => {
+            it("should use correct message template if failed to parse package.json", async () => {
                 const cwd = getFixturePath("ignored-paths", "broken-package-json");
 
                 assert.throw(() => {
@@ -4518,7 +4519,7 @@ describe("CLIEngine", () => {
                 });
             });
 
-            it("should not use package.json's eslintIgnore files if specified .eslintignore file", () => {
+            it("should not use package.json's eslintIgnore files if specified .eslintignore file", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ cwd });
 
@@ -4531,7 +4532,7 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored("sampleignorepattern"));
             });
 
-            it("should error if package.json's eslintIgnore is not an array of file paths", () => {
+            it("should error if package.json's eslintIgnore is not an array of file paths", async () => {
                 const cwd = getFixturePath("ignored-paths", "bad-package-json-ignore");
 
                 assert.throws(() => {
@@ -4542,7 +4543,7 @@ describe("CLIEngine", () => {
         });
 
         describe("with --ignore-pattern option", () => {
-            it("should accept a string for options.ignorePattern", () => {
+            it("should accept a string for options.ignorePattern", async () => {
                 const cwd = getFixturePath("ignored-paths", "ignore-pattern");
                 const engine = new CLIEngine({
                     ignorePattern: "ignore-me.txt",
@@ -4552,7 +4553,7 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored("ignore-me.txt"));
             });
 
-            it("should accept an array for options.ignorePattern", () => {
+            it("should accept an array for options.ignorePattern", async () => {
                 const engine = new CLIEngine({
                     ignorePattern: ["a", "b"],
                     useEslintrc: false
@@ -4563,7 +4564,7 @@ describe("CLIEngine", () => {
                 assert(!engine.isPathIgnored("c"));
             });
 
-            it("should return true for files which match an ignorePattern even if they do not exist on the filesystem", () => {
+            it("should return true for files which match an ignorePattern even if they do not exist on the filesystem", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({
                     ignorePattern: "not-a-file",
@@ -4573,49 +4574,49 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored(getFixturePath("ignored-paths", "not-a-file")));
             });
 
-            it("should return true for file matching an ignore pattern exactly", () => {
+            it("should return true for file matching an ignore pattern exactly", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ ignorePattern: "undef.js", cwd });
 
                 assert(engine.isPathIgnored(getFixturePath("ignored-paths", "undef.js")));
             });
 
-            it("should return false for file matching an invalid ignore pattern with leading './'", () => {
+            it("should return false for file matching an invalid ignore pattern with leading './'", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ ignorePattern: "./undef.js", cwd });
 
                 assert(!engine.isPathIgnored(getFixturePath("ignored-paths", "undef.js")));
             });
 
-            it("should return false for file in subfolder of cwd matching an ignore pattern with leading '/'", () => {
+            it("should return false for file in subfolder of cwd matching an ignore pattern with leading '/'", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ ignorePattern: "/undef.js", cwd });
 
                 assert(!engine.isPathIgnored(getFixturePath("ignored-paths", "subdir", "undef.js")));
             });
 
-            it("should return true for file matching a child of an ignore pattern", () => {
+            it("should return true for file matching a child of an ignore pattern", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ ignorePattern: "ignore-pattern", cwd });
 
                 assert(engine.isPathIgnored(getFixturePath("ignored-paths", "ignore-pattern", "ignore-me.txt")));
             });
 
-            it("should return true for file matching a grandchild of an ignore pattern", () => {
+            it("should return true for file matching a grandchild of an ignore pattern", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ ignorePattern: "ignore-pattern", cwd });
 
                 assert(engine.isPathIgnored(getFixturePath("ignored-paths", "ignore-pattern", "subdir", "ignore-me.txt")));
             });
 
-            it("should return false for file not matching any ignore pattern", () => {
+            it("should return false for file not matching any ignore pattern", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ ignorePattern: "failing.js", cwd });
 
                 assert(!engine.isPathIgnored(getFixturePath("ignored-paths", "unignored.js")));
             });
 
-            it("two globstar '**' ignore pattern should ignore files in nested directories", () => {
+            it("two globstar '**' ignore pattern should ignore files in nested directories", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ ignorePattern: "**/*.js", cwd });
 
@@ -4629,7 +4630,7 @@ describe("CLIEngine", () => {
         });
 
         describe("with --ignore-path option", () => {
-            it("should load empty array with ignorePath set to false", () => {
+            it("should load empty array with ignorePath set to false", async () => {
                 const cwd = getFixturePath("ignored-paths", "no-ignore-file");
                 const engine = new CLIEngine({ ignorePath: false, cwd });
 
@@ -4638,7 +4639,7 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored("node_modules/foo.js"));
             });
 
-            it("initialization with ignorePath should work when cwd is a parent directory", () => {
+            it("initialization with ignorePath should work when cwd is a parent directory", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const ignorePath = getFixturePath("ignored-paths", "custom-name", "ignore-file");
                 const engine = new CLIEngine({ ignorePath, cwd });
@@ -4646,7 +4647,7 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored("custom-name/foo.js"));
             });
 
-            it("initialization with ignorePath should work when the file is in the cwd", () => {
+            it("initialization with ignorePath should work when the file is in the cwd", async () => {
                 const cwd = getFixturePath("ignored-paths", "custom-name");
                 const ignorePath = getFixturePath("ignored-paths", "custom-name", "ignore-file");
                 const engine = new CLIEngine({ ignorePath, cwd });
@@ -4654,7 +4655,7 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored("foo.js"));
             });
 
-            it("initialization with ignorePath should work when cwd is a subdirectory", () => {
+            it("initialization with ignorePath should work when cwd is a subdirectory", async () => {
                 const cwd = getFixturePath("ignored-paths", "custom-name", "subdirectory");
                 const ignorePath = getFixturePath("ignored-paths", "custom-name", "ignore-file");
                 const engine = new CLIEngine({ ignorePath, cwd });
@@ -4662,7 +4663,7 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored("../custom-name/foo.js"));
             });
 
-            it("initialization with invalid file should throw error", () => {
+            it("initialization with invalid file should throw error", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const ignorePath = getFixturePath("ignored-paths", "not-a-directory", ".foobaz");
 
@@ -4672,7 +4673,7 @@ describe("CLIEngine", () => {
                 }, "Cannot read .eslintignore file");
             });
 
-            it("should return false for files outside of ignorePath's directory", () => {
+            it("should return false for files outside of ignorePath's directory", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const ignorePath = getFixturePath("ignored-paths", "custom-name", "ignore-file");
                 const engine = new CLIEngine({ ignorePath, cwd });
@@ -4680,7 +4681,7 @@ describe("CLIEngine", () => {
                 assert(!engine.isPathIgnored(getFixturePath("ignored-paths", "undef.js")));
             });
 
-            it("should resolve relative paths from CWD", () => {
+            it("should resolve relative paths from CWD", async () => {
                 const cwd = getFixturePath("ignored-paths", "subdir");
                 const ignorePath = getFixturePath("ignored-paths", ".eslintignoreForDifferentCwd");
                 const engine = new CLIEngine({ ignorePath, cwd });
@@ -4689,7 +4690,7 @@ describe("CLIEngine", () => {
                 assert(!engine.isPathIgnored(getFixturePath("ignored-paths", "undef.js")));
             });
 
-            it("should resolve relative paths from CWD when it's in a child directory", () => {
+            it("should resolve relative paths from CWD when it's in a child directory", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const ignorePath = getFixturePath("ignored-paths", "subdir/.eslintignoreInChildDir");
                 const engine = new CLIEngine({ ignorePath, cwd });
@@ -4702,7 +4703,7 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored(getFixturePath("ignored-paths", "node_modules/bar.js")));
             });
 
-            it("should resolve relative paths from CWD when it contains negated globs", () => {
+            it("should resolve relative paths from CWD when it contains negated globs", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const ignorePath = getFixturePath("ignored-paths", "subdir/.eslintignoreInChildDir");
                 const engine = new CLIEngine({ ignorePath, cwd });
@@ -4715,7 +4716,7 @@ describe("CLIEngine", () => {
                 assert(!engine.isPathIgnored("baz.txt"));
             });
 
-            it("should resolve default ignore patterns from the CWD even when the ignorePath is in a subdirectory", () => {
+            it("should resolve default ignore patterns from the CWD even when the ignorePath is in a subdirectory", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const ignorePath = getFixturePath("ignored-paths", "subdir/.eslintignoreInChildDir");
                 const engine = new CLIEngine({ ignorePath, cwd });
@@ -4723,7 +4724,7 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored("node_modules/blah.js"));
             });
 
-            it("should resolve default ignore patterns from the CWD even when the ignorePath is in a parent directory", () => {
+            it("should resolve default ignore patterns from the CWD even when the ignorePath is in a parent directory", async () => {
                 const cwd = getFixturePath("ignored-paths", "subdir");
                 const ignorePath = getFixturePath("ignored-paths", ".eslintignoreForDifferentCwd");
                 const engine = new CLIEngine({ ignorePath, cwd });
@@ -4731,7 +4732,7 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored("node_modules/blah.js"));
             });
 
-            it("should handle .eslintignore which contains CRLF correctly.", () => {
+            it("should handle .eslintignore which contains CRLF correctly.", async () => {
                 const ignoreFileContent = fs.readFileSync(getFixturePath("ignored-paths", "crlf/.eslintignore"), "utf8");
 
                 assert(ignoreFileContent.includes("\r"), "crlf/.eslintignore should contains CR.");
@@ -4745,7 +4746,7 @@ describe("CLIEngine", () => {
                 assert(!engine.isPathIgnored(getFixturePath("ignored-paths", "crlf/hide3/a.js")));
             });
 
-            it("should not include comments in ignore rules", () => {
+            it("should not include comments in ignore rules", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const ignorePath = getFixturePath("ignored-paths", ".eslintignoreWithComments");
                 const engine = new CLIEngine({ ignorePath, cwd });
@@ -4754,7 +4755,7 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored("this_one_not"));
             });
 
-            it("should ignore a non-negated pattern", () => {
+            it("should ignore a non-negated pattern", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const ignorePath = getFixturePath("ignored-paths", ".eslintignoreWithNegation");
                 const engine = new CLIEngine({ ignorePath, cwd });
@@ -4762,7 +4763,7 @@ describe("CLIEngine", () => {
                 assert(engine.isPathIgnored(getFixturePath("ignored-paths", "negation", "ignore.js")));
             });
 
-            it("should not ignore a negated pattern", () => {
+            it("should not ignore a negated pattern", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const ignorePath = getFixturePath("ignored-paths", ".eslintignoreWithNegation");
                 const engine = new CLIEngine({ ignorePath, cwd });
@@ -4772,7 +4773,7 @@ describe("CLIEngine", () => {
         });
 
         describe("with --ignore-path option and --ignore-pattern option", () => {
-            it("should return false for ignored file when unignored with ignore pattern", () => {
+            it("should return false for ignored file when unignored with ignore pattern", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({
                     ignorePath: getFixturePath("ignored-paths", ".eslintignore"),
@@ -4787,28 +4788,28 @@ describe("CLIEngine", () => {
 
     describe("getFormatter()", () => {
 
-        it("should return a function when a bundled formatter is requested", () => {
+        it("should return a function when a bundled formatter is requested", async () => {
             const engine = new CLIEngine(),
                 formatter = engine.getFormatter("compact");
 
             assert.isFunction(formatter);
         });
 
-        it("should return a function when no argument is passed", () => {
+        it("should return a function when no argument is passed", async () => {
             const engine = new CLIEngine(),
                 formatter = engine.getFormatter();
 
             assert.isFunction(formatter);
         });
 
-        it("should return a function when a custom formatter is requested", () => {
+        it("should return a function when a custom formatter is requested", async () => {
             const engine = new CLIEngine(),
                 formatter = engine.getFormatter(getFixturePath("formatters", "simple.js"));
 
             assert.isFunction(formatter);
         });
 
-        it("should return a function when a custom formatter is requested, also if the path has backslashes", () => {
+        it("should return a function when a custom formatter is requested, also if the path has backslashes", async () => {
             const engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
                 }),
@@ -4817,7 +4818,7 @@ describe("CLIEngine", () => {
             assert.isFunction(formatter);
         });
 
-        it("should return a function when a formatter prefixed with eslint-formatter is requested", () => {
+        it("should return a function when a formatter prefixed with eslint-formatter is requested", async () => {
             const engine = new CLIEngine({
                     cwd: getFixturePath("cli-engine")
                 }),
@@ -4826,7 +4827,7 @@ describe("CLIEngine", () => {
             assert.isFunction(formatter);
         });
 
-        it("should return a function when a formatter is requested, also when the eslint-formatter prefix is included in the format argument", () => {
+        it("should return a function when a formatter is requested, also when the eslint-formatter prefix is included in the format argument", async () => {
             const engine = new CLIEngine({
                     cwd: getFixturePath("cli-engine")
                 }),
@@ -4835,7 +4836,7 @@ describe("CLIEngine", () => {
             assert.isFunction(formatter);
         });
 
-        it("should return a function when a formatter is requested within a scoped npm package", () => {
+        it("should return a function when a formatter is requested within a scoped npm package", async () => {
             const engine = new CLIEngine({
                     cwd: getFixturePath("cli-engine")
                 }),
@@ -4844,7 +4845,7 @@ describe("CLIEngine", () => {
             assert.isFunction(formatter);
         });
 
-        it("should return a function when a formatter is requested within a scoped npm package, also when the eslint-formatter prefix is included in the format argument", () => {
+        it("should return a function when a formatter is requested within a scoped npm package, also when the eslint-formatter prefix is included in the format argument", async () => {
             const engine = new CLIEngine({
                     cwd: getFixturePath("cli-engine")
                 }),
@@ -4853,7 +4854,7 @@ describe("CLIEngine", () => {
             assert.isFunction(formatter);
         });
 
-        it("should return null when a custom formatter doesn't exist", () => {
+        it("should return null when a custom formatter doesn't exist", async () => {
             const engine = new CLIEngine(),
                 formatterPath = getFixturePath("formatters", "doesntexist.js"),
                 fullFormatterPath = path.resolve(formatterPath);
@@ -4863,7 +4864,7 @@ describe("CLIEngine", () => {
             }, `There was a problem loading formatter: ${fullFormatterPath}\nError: Cannot find module '${fullFormatterPath}'`);
         });
 
-        it("should return null when a built-in formatter doesn't exist", () => {
+        it("should return null when a built-in formatter doesn't exist", async () => {
             const engine = new CLIEngine();
             const fullFormatterPath = path.resolve(__dirname, "../../../lib/cli-engine/formatters/special");
 
@@ -4872,7 +4873,7 @@ describe("CLIEngine", () => {
             }, `There was a problem loading formatter: ${fullFormatterPath}\nError: Cannot find module '${fullFormatterPath}'`);
         });
 
-        it("should throw when a built-in formatter no longer exists", () => {
+        it("should throw when a built-in formatter no longer exists", async () => {
             const engine = new CLIEngine();
 
             assert.throws(() => {
@@ -4884,7 +4885,7 @@ describe("CLIEngine", () => {
             }, "The codeframe formatter is no longer part of core ESLint. Install it manually with `npm install -D eslint-formatter-codeframe`");
         });
 
-        it("should throw if the required formatter exists but has an error", () => {
+        it("should throw if the required formatter exists but has an error", async () => {
             const engine = new CLIEngine(),
                 formatterPath = getFixturePath("formatters", "broken.js");
 
@@ -4893,20 +4894,20 @@ describe("CLIEngine", () => {
             }, `There was a problem loading formatter: ${formatterPath}\nError: Cannot find module 'this-module-does-not-exist'`);
         });
 
-        it("should return null when a non-string formatter name is passed", () => {
+        it("should return null when a non-string formatter name is passed", async () => {
             const engine = new CLIEngine(),
                 formatter = engine.getFormatter(5);
 
             assert.isNull(formatter);
         });
 
-        it("should return a function when called as a static function on CLIEngine", () => {
+        it("should return a function when called as a static function on CLIEngine", async () => {
             const formatter = CLIEngine.getFormatter();
 
             assert.isFunction(formatter);
         });
 
-        it("should return a function when called as a static function on CLIEngine and a custom formatter is requested", () => {
+        it("should return a function when called as a static function on CLIEngine and a custom formatter is requested", async () => {
             const formatter = CLIEngine.getFormatter(getFixturePath("formatters", "simple.js"));
 
             assert.isFunction(formatter);
@@ -4915,7 +4916,7 @@ describe("CLIEngine", () => {
     });
 
     describe("getErrorResults()", () => {
-        it("should report 5 error messages when looking for errors only", () => {
+        it("should report 5 error messages when looking for errors only", async () => {
 
             process.chdir(originalDir);
             const engine = new CLIEngine({
@@ -4934,7 +4935,7 @@ describe("CLIEngine", () => {
                 }
             });
 
-            const report = engine.executeOnText("var foo = 'bar';");
+            const report = await engine.executeOnText("var foo = 'bar';");
             const errorResults = CLIEngine.getErrorResults(report.results);
 
             assert.lengthOf(errorResults[0].messages, 5);
@@ -4954,7 +4955,7 @@ describe("CLIEngine", () => {
             assert.lengthOf(errorResults[0].suppressedMessages, 0);
         });
 
-        it("should report no error messages when looking for errors only", () => {
+        it("should report no error messages when looking for errors only", async () => {
             process.chdir(originalDir);
             const engine = new CLIEngine({
                 useEslintrc: false,
@@ -4972,13 +4973,13 @@ describe("CLIEngine", () => {
                 }
             });
 
-            const report = engine.executeOnText("var foo = 'bar'; // eslint-disable-line strict, no-var, no-unused-vars, quotes, eol-last -- justification");
+            const report = await engine.executeOnText("var foo = 'bar'; // eslint-disable-line strict, no-var, no-unused-vars, quotes, eol-last -- justification");
             const errorResults = CLIEngine.getErrorResults(report.results);
 
             assert.lengthOf(errorResults, 0);
         });
 
-        it("should not mutate passed report.results parameter", () => {
+        it("should not mutate passed report.results parameter", async () => {
             process.chdir(originalDir);
             const engine = new CLIEngine({
                 useEslintrc: false,
@@ -4988,7 +4989,7 @@ describe("CLIEngine", () => {
                 }
             });
 
-            const report = engine.executeOnText("var foo = 'bar';");
+            const report = await engine.executeOnText("var foo = 'bar';");
             const reportResultsLength = report.results[0].messages.length;
 
             assert.strictEqual(report.results[0].messages.length, 2);
@@ -4998,7 +4999,7 @@ describe("CLIEngine", () => {
             assert.lengthOf(report.results[0].messages, reportResultsLength);
         });
 
-        it("should report no suppressed error messages when looking for errors only", () => {
+        it("should report no suppressed error messages when looking for errors only", async () => {
             process.chdir(originalDir);
             const engine = new CLIEngine({
                 useEslintrc: false,
@@ -5014,7 +5015,7 @@ describe("CLIEngine", () => {
                 }
             });
 
-            const report = engine.executeOnText("var foo = 'bar'; // eslint-disable-line quotes -- justification\n");
+            const report = await engine.executeOnText("var foo = 'bar'; // eslint-disable-line quotes -- justification\n");
             const errorResults = CLIEngine.getErrorResults(report.results);
 
             assert.lengthOf(report.results[0].messages, 3);
@@ -5023,7 +5024,7 @@ describe("CLIEngine", () => {
             assert.lengthOf(errorResults[0].suppressedMessages, 0);
         });
 
-        it("should report a warningCount of 0 when looking for errors only", () => {
+        it("should report a warningCount of 0 when looking for errors only", async () => {
 
             process.chdir(originalDir);
             const engine = new CLIEngine({
@@ -5042,20 +5043,20 @@ describe("CLIEngine", () => {
                 }
             });
 
-            const report = engine.executeOnText("var foo = 'bar';");
+            const report = await engine.executeOnText("var foo = 'bar';");
             const errorResults = CLIEngine.getErrorResults(report.results);
 
             assert.strictEqual(errorResults[0].warningCount, 0);
             assert.strictEqual(errorResults[0].fixableWarningCount, 0);
         });
 
-        it("should return 0 error or warning messages even when the file has warnings", () => {
+        it("should return 0 error or warning messages even when the file has warnings", async () => {
             const engine = new CLIEngine({
                 ignorePath: path.join(fixtureDir, ".eslintignore"),
                 cwd: path.join(fixtureDir, "..")
             });
 
-            const report = engine.executeOnText("var bar = foo;", "fixtures/passing.js", true);
+            const report = await engine.executeOnText("var bar = foo;", "fixtures/passing.js", true);
             const errorReport = CLIEngine.getErrorResults(report.results);
 
             assert.lengthOf(errorReport, 0);
@@ -5072,7 +5073,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].fixableWarningCount, 0);
         });
 
-        it("should return source code of file in the `source` property", () => {
+        it("should return source code of file in the `source` property", async () => {
             process.chdir(originalDir);
             const engine = new CLIEngine({
                 useEslintrc: false,
@@ -5080,14 +5081,14 @@ describe("CLIEngine", () => {
             });
 
 
-            const report = engine.executeOnText("var foo = 'bar';");
+            const report = await engine.executeOnText("var foo = 'bar';");
             const errorResults = CLIEngine.getErrorResults(report.results);
 
             assert.lengthOf(errorResults[0].messages, 1);
             assert.strictEqual(errorResults[0].source, "var foo = 'bar';");
         });
 
-        it("should contain `output` property after fixes", () => {
+        it("should contain `output` property after fixes", async () => {
             process.chdir(originalDir);
             const engine = new CLIEngine({
                 useEslintrc: false,
@@ -5098,7 +5099,7 @@ describe("CLIEngine", () => {
                 }
             });
 
-            const report = engine.executeOnText("console.log('foo')");
+            const report = await engine.executeOnText("console.log('foo')");
             const errorResults = CLIEngine.getErrorResults(report.results);
 
             assert.lengthOf(errorResults[0].messages, 1);
@@ -5111,7 +5112,7 @@ describe("CLIEngine", () => {
             sinon.verifyAndRestore();
         });
 
-        it("should call fs.writeFileSync() for each result with output", () => {
+        it("should call fs.writeFileSync() for each result with output", async () => {
             const fakeFS = {
                     writeFileSync() {}
                 },
@@ -5141,7 +5142,7 @@ describe("CLIEngine", () => {
 
         });
 
-        it("should call fs.writeFileSync() for each result with output and not at all for a result without output", () => {
+        it("should call fs.writeFileSync() for each result with output and not at all for a result without output", async () => {
             const fakeFS = {
                     writeFileSync() {}
                 },
@@ -5177,7 +5178,7 @@ describe("CLIEngine", () => {
     });
 
     describe("getRules()", () => {
-        it("should expose the list of rules", () => {
+        it("should expose the list of rules", async () => {
             const engine = new CLIEngine();
 
             assert(engine.getRules().has("no-eval"), "no-eval is present");
@@ -5189,7 +5190,7 @@ describe("CLIEngine", () => {
             assert(engine.getRules().has("internal-rules/no-invalid-meta"), "internal-rules/no-invalid-meta is present");
         });
 
-        it("should expose the list of rules from a preloaded plugin", () => {
+        it("should expose the list of rules from a preloaded plugin", async () => {
             const engine = new CLIEngine({
                 plugins: ["foo"]
             }, {
@@ -5211,7 +5212,7 @@ describe("CLIEngine", () => {
             ["", []]
         ].forEach(([input, expected]) => {
 
-            it(`should correctly resolve ${input} to ${expected}`, () => {
+            it(`should correctly resolve ${input} to ${expected}`, async () => {
                 const engine = new CLIEngine();
 
                 const result = engine.resolveFileGlobPatterns([input]);
@@ -5221,7 +5222,7 @@ describe("CLIEngine", () => {
             });
         });
 
-        it("should convert a directory name with no provided extensions into a glob pattern", () => {
+        it("should convert a directory name with no provided extensions into a glob pattern", async () => {
             const patterns = ["one-js-file"];
             const opts = {
                 cwd: getFixturePath("glob-util")
@@ -5231,7 +5232,7 @@ describe("CLIEngine", () => {
             assert.deepStrictEqual(result, ["one-js-file/**/*.{js}"]);
         });
 
-        it("should not convert path with globInputPaths option false", () => {
+        it("should not convert path with globInputPaths option false", async () => {
             const patterns = ["one-js-file"];
             const opts = {
                 cwd: getFixturePath("glob-util"),
@@ -5242,7 +5243,7 @@ describe("CLIEngine", () => {
             assert.deepStrictEqual(result, ["one-js-file"]);
         });
 
-        it("should convert an absolute directory name with no provided extensions into a posix glob pattern", () => {
+        it("should convert an absolute directory name with no provided extensions into a posix glob pattern", async () => {
             const patterns = [getFixturePath("glob-util", "one-js-file")];
             const opts = {
                 cwd: getFixturePath("glob-util")
@@ -5253,7 +5254,7 @@ describe("CLIEngine", () => {
             assert.deepStrictEqual(result, expected);
         });
 
-        it("should convert a directory name with a single provided extension into a glob pattern", () => {
+        it("should convert a directory name with a single provided extension into a glob pattern", async () => {
             const patterns = ["one-js-file"];
             const opts = {
                 cwd: getFixturePath("glob-util"),
@@ -5264,7 +5265,7 @@ describe("CLIEngine", () => {
             assert.deepStrictEqual(result, ["one-js-file/**/*.{jsx}"]);
         });
 
-        it("should convert a directory name with multiple provided extensions into a glob pattern", () => {
+        it("should convert a directory name with multiple provided extensions into a glob pattern", async () => {
             const patterns = ["one-js-file"];
             const opts = {
                 cwd: getFixturePath("glob-util"),
@@ -5275,7 +5276,7 @@ describe("CLIEngine", () => {
             assert.deepStrictEqual(result, ["one-js-file/**/*.{jsx,js}"]);
         });
 
-        it("should convert multiple directory names into glob patterns", () => {
+        it("should convert multiple directory names into glob patterns", async () => {
             const patterns = ["one-js-file", "two-js-files"];
             const opts = {
                 cwd: getFixturePath("glob-util")
@@ -5285,7 +5286,7 @@ describe("CLIEngine", () => {
             assert.deepStrictEqual(result, ["one-js-file/**/*.{js}", "two-js-files/**/*.{js}"]);
         });
 
-        it("should remove leading './' from glob patterns", () => {
+        it("should remove leading './' from glob patterns", async () => {
             const patterns = ["./one-js-file"];
             const opts = {
                 cwd: getFixturePath("glob-util")
@@ -5295,7 +5296,7 @@ describe("CLIEngine", () => {
             assert.deepStrictEqual(result, ["one-js-file/**/*.{js}"]);
         });
 
-        it("should convert a directory name with a trailing '/' into a glob pattern", () => {
+        it("should convert a directory name with a trailing '/' into a glob pattern", async () => {
             const patterns = ["one-js-file/"];
             const opts = {
                 cwd: getFixturePath("glob-util")
@@ -5305,7 +5306,7 @@ describe("CLIEngine", () => {
             assert.deepStrictEqual(result, ["one-js-file/**/*.{js}"]);
         });
 
-        it("should return filenames as they are", () => {
+        it("should return filenames as they are", async () => {
             const patterns = ["some-file.js"];
             const opts = {
                 cwd: getFixturePath("glob-util")
@@ -5315,7 +5316,7 @@ describe("CLIEngine", () => {
             assert.deepStrictEqual(result, ["some-file.js"]);
         });
 
-        it("should convert backslashes into forward slashes", () => {
+        it("should convert backslashes into forward slashes", async () => {
             const patterns = ["one-js-file\\example.js"];
             const opts = {
                 cwd: getFixturePath()
@@ -5328,7 +5329,7 @@ describe("CLIEngine", () => {
 
     describe("when evaluating code with comments to change config when allowInlineConfig is disabled", () => {
 
-        it("should report a violation for disabling rules", () => {
+        it("should report a violation for disabling rules", async () => {
             const code = [
                 "alert('test'); // eslint-disable-line no-alert"
             ].join("\n");
@@ -5348,7 +5349,7 @@ describe("CLIEngine", () => {
 
             const eslintCLI = new CLIEngine(config);
 
-            const report = eslintCLI.executeOnText(code);
+            const report = await eslintCLI.executeOnText(code);
             const { messages, suppressedMessages } = report.results[0];
 
             assert.strictEqual(messages.length, 1);
@@ -5356,7 +5357,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(suppressedMessages.length, 0);
         });
 
-        it("should not report a violation by default", () => {
+        it("should not report a violation by default", async () => {
             const code = [
                 "alert('test'); // eslint-disable-line no-alert"
             ].join("\n");
@@ -5377,7 +5378,7 @@ describe("CLIEngine", () => {
 
             const eslintCLI = new CLIEngine(config);
 
-            const report = eslintCLI.executeOnText(code);
+            const report = await eslintCLI.executeOnText(code);
             const { messages, suppressedMessages } = report.results[0];
 
             assert.strictEqual(messages.length, 0);
@@ -5388,11 +5389,11 @@ describe("CLIEngine", () => {
     });
 
     describe("when evaluating code when reportUnusedDisableDirectives is enabled", () => {
-        it("should report problems for unused eslint-disable directives", () => {
+        it("should report problems for unused eslint-disable directives", async () => {
             const cliEngine = new CLIEngine({ useEslintrc: false, reportUnusedDisableDirectives: true });
 
             assert.deepStrictEqual(
-                cliEngine.executeOnText("/* eslint-disable */"),
+                await cliEngine.executeOnText("/* eslint-disable */"),
                 {
                     results: [
                         {
@@ -5432,7 +5433,7 @@ describe("CLIEngine", () => {
     });
 
     describe("when retrieving version number", () => {
-        it("should return current version number", () => {
+        it("should return current version number", async () => {
             const eslintCLI = require("../../../lib/cli-engine").CLIEngine;
             const version = eslintCLI.version;
 
@@ -5443,7 +5444,7 @@ describe("CLIEngine", () => {
 
     describe("mutability", () => {
         describe("plugins", () => {
-            it("Loading plugin in one instance doesn't mutate to another instance", () => {
+            it("Loading plugin in one instance doesn't mutate to another instance", async () => {
                 const filePath = getFixturePath("single-quoted.js");
                 const engine1 = cliEngineWithPlugins({
                     cwd: path.join(fixtureDir, ".."),
@@ -5465,7 +5466,7 @@ describe("CLIEngine", () => {
         });
 
         describe("rules", () => {
-            it("Loading rules in one instance doesn't mutate to another instance", () => {
+            it("Loading rules in one instance doesn't mutate to another instance", async () => {
                 const filePath = getFixturePath("single-quoted.js");
                 const engine1 = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
@@ -5507,23 +5508,23 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'isPathIgnored()' should return 'true' for 'foo.js'.", () => {
+            it("'isPathIgnored()' should return 'true' for 'foo.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("foo.js"), true);
                 assert.strictEqual(engine.isPathIgnored("subdir/foo.js"), true);
             });
 
-            it("'isPathIgnored()' should return 'false' for 'bar.js'.", () => {
+            it("'isPathIgnored()' should return 'false' for 'bar.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("bar.js"), false);
                 assert.strictEqual(engine.isPathIgnored("subdir/bar.js"), false);
             });
 
-            it("'executeOnFiles()' should not verify 'foo.js'.", () => {
+            it("'executeOnFiles()' should not verify 'foo.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles("**/*.js")
+                const filePaths = (await engine.executeOnFiles("**/*.js"))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -5554,23 +5555,23 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'isPathIgnored()' should return 'true' for 'foo.js'.", () => {
+            it("'isPathIgnored()' should return 'true' for 'foo.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("foo.js"), true);
                 assert.strictEqual(engine.isPathIgnored("subdir/foo.js"), true);
             });
 
-            it("'isPathIgnored()' should return 'true' for '/bar.js'.", () => {
+            it("'isPathIgnored()' should return 'true' for '/bar.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("bar.js"), true);
                 assert.strictEqual(engine.isPathIgnored("subdir/bar.js"), false);
             });
 
-            it("'executeOnFiles()' should not verify 'foo.js' and '/bar.js'.", () => {
+            it("'executeOnFiles()' should not verify 'foo.js' and '/bar.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles("**/*.js")
+                const filePaths = (await engine.executeOnFiles("**/*.js"))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -5601,27 +5602,27 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'isPathIgnored()' should return 'false' for 'node_modules/foo/index.js'.", () => {
+            it("'isPathIgnored()' should return 'false' for 'node_modules/foo/index.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("node_modules/foo/index.js"), false);
             });
 
-            it("'isPathIgnored()' should return 'true' for 'node_modules/foo/.dot.js'.", () => {
+            it("'isPathIgnored()' should return 'true' for 'node_modules/foo/.dot.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("node_modules/foo/.dot.js"), true);
             });
 
-            it("'isPathIgnored()' should return 'true' for 'node_modules/bar/index.js'.", () => {
+            it("'isPathIgnored()' should return 'true' for 'node_modules/bar/index.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("node_modules/bar/index.js"), true);
             });
 
-            it("'executeOnFiles()' should verify 'node_modules/foo/index.js'.", () => {
+            it("'executeOnFiles()' should verify 'node_modules/foo/index.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles("**/*.js")
+                const filePaths = (await engine.executeOnFiles("**/*.js"))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -5648,15 +5649,15 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'isPathIgnored()' should return 'false' for '.eslintrc.js'.", () => {
+            it("'isPathIgnored()' should return 'false' for '.eslintrc.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored(".eslintrc.js"), false);
             });
 
-            it("'executeOnFiles()' should verify '.eslintrc.js'.", () => {
+            it("'executeOnFiles()' should verify '.eslintrc.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles("**/*.js")
+                const filePaths = (await engine.executeOnFiles("**/*.js"))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -5684,21 +5685,21 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'isPathIgnored()' should return 'true' for re-ignored '.foo.js'.", () => {
+            it("'isPathIgnored()' should return 'true' for re-ignored '.foo.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored(".foo.js"), true);
             });
 
-            it("'isPathIgnored()' should return 'false' for unignored '.bar.js'.", () => {
+            it("'isPathIgnored()' should return 'false' for unignored '.bar.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored(".bar.js"), false);
             });
 
-            it("'executeOnFiles()' should not verify re-ignored '.foo.js'.", () => {
+            it("'executeOnFiles()' should not verify re-ignored '.foo.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles("**/*.js")
+                const filePaths = (await engine.executeOnFiles("**/*.js"))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -5727,21 +5728,21 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'isPathIgnored()' should return 'false' for unignored 'foo.js'.", () => {
+            it("'isPathIgnored()' should return 'false' for unignored 'foo.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("foo.js"), false);
             });
 
-            it("'isPathIgnored()' should return 'true' for ignored 'bar.js'.", () => {
+            it("'isPathIgnored()' should return 'true' for ignored 'bar.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("bar.js"), true);
             });
 
-            it("'executeOnFiles()' should verify unignored 'foo.js'.", () => {
+            it("'executeOnFiles()' should verify unignored 'foo.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles("**/*.js")
+                const filePaths = (await engine.executeOnFiles("**/*.js"))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -5774,7 +5775,7 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'isPathIgnored()' should return 'true' for 'foo.js'.", () => {
+            it("'isPathIgnored()' should return 'true' for 'foo.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("foo.js"), true);
@@ -5782,22 +5783,22 @@ describe("CLIEngine", () => {
                 assert.strictEqual(engine.isPathIgnored("subdir/subsubdir/foo.js"), true);
             });
 
-            it("'isPathIgnored()' should return 'true' for 'bar.js' in 'subdir'.", () => {
+            it("'isPathIgnored()' should return 'true' for 'bar.js' in 'subdir'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("subdir/bar.js"), true);
                 assert.strictEqual(engine.isPathIgnored("subdir/subsubdir/bar.js"), true);
             });
 
-            it("'isPathIgnored()' should return 'false' for 'bar.js' in the outside of 'subdir'.", () => {
+            it("'isPathIgnored()' should return 'false' for 'bar.js' in the outside of 'subdir'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("bar.js"), false);
             });
 
-            it("'executeOnFiles()' should verify 'bar.js' in the outside of 'subdir'.", () => {
+            it("'executeOnFiles()' should verify 'bar.js' in the outside of 'subdir'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles("**/*.js")
+                const filePaths = (await engine.executeOnFiles("**/*.js"))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -5826,21 +5827,21 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'isPathIgnored()' should return 'true' for 'foo.js' in the root directory.", () => {
+            it("'isPathIgnored()' should return 'true' for 'foo.js' in the root directory.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("foo.js"), true);
             });
 
-            it("'isPathIgnored()' should return 'false' for 'foo.js' in the child directory.", () => {
+            it("'isPathIgnored()' should return 'false' for 'foo.js' in the child directory.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("subdir/foo.js"), false);
             });
 
-            it("'executeOnFiles()' should verify 'foo.js' in the child directory.", () => {
+            it("'executeOnFiles()' should verify 'foo.js' in the child directory.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles("**/*.js")
+                const filePaths = (await engine.executeOnFiles("**/*.js"))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -5869,22 +5870,22 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'isPathIgnored()' should return 'false' for unignored 'foo.js'.", () => {
+            it("'isPathIgnored()' should return 'false' for unignored 'foo.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("foo.js"), false);
                 assert.strictEqual(engine.isPathIgnored("subdir/foo.js"), false);
             });
 
-            it("'isPathIgnored()' should return 'true' for ignored 'bar.js'.", () => {
+            it("'isPathIgnored()' should return 'true' for ignored 'bar.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("subdir/bar.js"), true);
             });
 
-            it("'executeOnFiles()' should verify unignored 'foo.js'.", () => {
+            it("'executeOnFiles()' should verify unignored 'foo.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles("**/*.js")
+                const filePaths = (await engine.executeOnFiles("**/*.js"))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -5917,33 +5918,33 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'isPathIgnored()' should return 'true' for 'foo.js' in the root directory.", () => {
+            it("'isPathIgnored()' should return 'true' for 'foo.js' in the root directory.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("foo.js"), true);
             });
 
-            it("'isPathIgnored()' should return 'false' for 'bar.js' in the root directory.", () => {
+            it("'isPathIgnored()' should return 'false' for 'bar.js' in the root directory.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("bar.js"), false);
             });
 
-            it("'isPathIgnored()' should return 'false' for 'foo.js' in the child directory.", () => {
+            it("'isPathIgnored()' should return 'false' for 'foo.js' in the child directory.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("subdir/foo.js"), false);
             });
 
-            it("'isPathIgnored()' should return 'true' for 'bar.js' in the child directory.", () => {
+            it("'isPathIgnored()' should return 'true' for 'bar.js' in the child directory.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("subdir/bar.js"), true);
             });
 
-            it("'executeOnFiles()' should verify 'bar.js' in the root directory and 'foo.js' in the child directory.", () => {
+            it("'executeOnFiles()' should verify 'bar.js' in the root directory and 'foo.js' in the child directory.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles("**/*.js")
+                const filePaths = (await engine.executeOnFiles("**/*.js"))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -5976,28 +5977,28 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'isPathIgnored()' should return 'true' for 'foo.js'.", () => {
+            it("'isPathIgnored()' should return 'true' for 'foo.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("foo.js"), true);
                 assert.strictEqual(engine.isPathIgnored("subdir/foo.js"), true);
             });
 
-            it("'isPathIgnored()' should return 'false' for 'bar.js' in the root directory.", () => {
+            it("'isPathIgnored()' should return 'false' for 'bar.js' in the root directory.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("bar.js"), false);
             });
 
-            it("'isPathIgnored()' should return 'true' for 'bar.js' in the child directory.", () => {
+            it("'isPathIgnored()' should return 'true' for 'bar.js' in the child directory.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("subdir/bar.js"), true);
             });
 
-            it("'executeOnFiles()' should verify 'bar.js' in the root directory.", () => {
+            it("'executeOnFiles()' should verify 'bar.js' in the root directory.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles("**/*.js")
+                const filePaths = (await engine.executeOnFiles("**/*.js"))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -6026,21 +6027,21 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'isPathIgnored()' should return 'true' for 'foo.js'.", () => {
+            it("'isPathIgnored()' should return 'true' for 'foo.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("foo.js"), true);
             });
 
-            it("'isPathIgnored()' should return 'false' for 'bar.js'.", () => {
+            it("'isPathIgnored()' should return 'false' for 'bar.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("bar.js"), false);
             });
 
-            it("'executeOnFiles()' should verify 'bar.js'.", () => {
+            it("'executeOnFiles()' should verify 'bar.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles("**/*.js")
+                const filePaths = (await engine.executeOnFiles("**/*.js"))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -6071,21 +6072,21 @@ describe("CLIEngine", () => {
             afterEach(cleanup);
 
 
-            it("'isPathIgnored()' should return 'true' for 'foo.js'.", () => {
+            it("'isPathIgnored()' should return 'true' for 'foo.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("foo.js"), true);
             });
 
-            it("'isPathIgnored()' should return 'false' for 'subdir/foo.js'.", () => {
+            it("'isPathIgnored()' should return 'false' for 'subdir/foo.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("subdir/foo.js"), false);
             });
 
-            it("'executeOnFiles()' should verify 'subdir/foo.js'.", () => {
+            it("'executeOnFiles()' should verify 'subdir/foo.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles("**/*.js")
+                const filePaths = (await engine.executeOnFiles("**/*.js"))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -6116,21 +6117,21 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'isPathIgnored()' should return 'true' for 'foo.js'.", () => {
+            it("'isPathIgnored()' should return 'true' for 'foo.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("foo.js"), true);
             });
 
-            it("'isPathIgnored()' should return 'false' for 'bar.js'.", () => {
+            it("'isPathIgnored()' should return 'false' for 'bar.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
                 assert.strictEqual(engine.isPathIgnored("bar.js"), false);
             });
 
-            it("'executeOnFiles()' should verify 'bar.js'.", () => {
+            it("'executeOnFiles()' should verify 'bar.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles("**/*.js")
+                const filePaths = (await engine.executeOnFiles("**/*.js"))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -6155,15 +6156,15 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'isPathIgnored()' should return 'false' for 'foo.js'.", () => {
+            it("'isPathIgnored()' should return 'false' for 'foo.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath(), ignore: false });
 
                 assert.strictEqual(engine.isPathIgnored("foo.js"), false);
             });
 
-            it("'executeOnFiles()' should verify 'foo.js'.", () => {
+            it("'executeOnFiles()' should verify 'foo.js'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath(), ignore: false });
-                const filePaths = engine.executeOnFiles("**/*.js")
+                const filePaths = (await engine.executeOnFiles("**/*.js"))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -6194,12 +6195,12 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("should throw a configuration error.", () => {
-                assert.throws(() => {
+            it("should throw a configuration error.", async () => {
+                await nodeAssert.rejects(async () => {
                     const engine = new CLIEngine({ cwd: getPath() });
 
-                    engine.executeOnFiles("*.js");
-                }, "Unexpected top-level property \"overrides[0].ignorePatterns\"");
+                    await engine.executeOnFiles("*.js");
+                }, /Unexpected top-level property "overrides\[0\]\.ignorePatterns"/u);
             });
         });
 
@@ -6237,9 +6238,9 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'executeOnFiles()' with a directory path should contain 'foo/test.txt'.", () => {
+            it("'executeOnFiles()' with a directory path should contain 'foo/test.txt'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles(".")
+                const filePaths = (await engine.executeOnFiles("."))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -6252,9 +6253,9 @@ describe("CLIEngine", () => {
                 ]);
             });
 
-            it("'executeOnFiles()' with a glob pattern '*.js' should not contain 'foo/test.txt'.", () => {
+            it("'executeOnFiles()' with a glob pattern '*.js' should not contain 'foo/test.txt'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles("**/*.js")
+                const filePaths = (await engine.executeOnFiles("**/*.js"))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -6292,9 +6293,9 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'executeOnFiles()' with a directory path should contain 'foo/test.txt' and 'foo/nested/test.txt'.", () => {
+            it("'executeOnFiles()' with a directory path should contain 'foo/test.txt' and 'foo/nested/test.txt'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles(".")
+                const filePaths = (await engine.executeOnFiles("."))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -6333,9 +6334,9 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'executeOnFiles()' with a directory path should NOT contain 'foo/test.txt' and 'foo/nested/test.txt'.", () => {
+            it("'executeOnFiles()' with a directory path should NOT contain 'foo/test.txt' and 'foo/nested/test.txt'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles(".")
+                const filePaths = (await engine.executeOnFiles("."))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -6375,9 +6376,9 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'executeOnFiles()' with a directory path should contain 'foo/test.txt' and 'foo/nested/test.txt'.", () => {
+            it("'executeOnFiles()' with a directory path should contain 'foo/test.txt' and 'foo/nested/test.txt'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles(".")
+                const filePaths = (await engine.executeOnFiles("."))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -6421,9 +6422,9 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'executeOnFiles()' with a directory path should contain 'foo/test.txt' and 'foo/nested/test.txt'.", () => {
+            it("'executeOnFiles()' with a directory path should contain 'foo/test.txt' and 'foo/nested/test.txt'.", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const filePaths = engine.executeOnFiles(".")
+                const filePaths = (await engine.executeOnFiles("."))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -6464,14 +6465,14 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'executeOnFiles()' with 'foo/test.js' should use the override entry.", () => {
+            it("'executeOnFiles()' with 'foo/test.js' should use the override entry.", async () => {
                 const engine = new CLIEngine({
                     configFile: "node_modules/myconf/.eslintrc.json",
                     cwd: getPath(),
                     ignore: false,
                     useEslintrc: false
                 });
-                const { results } = engine.executeOnFiles("foo/test.js");
+                const { results } = await engine.executeOnFiles("foo/test.js");
 
                 // Expected to be an 'eqeqeq' error because the file matches to `$CWD/foo/*.js`.
                 assert.deepStrictEqual(results, [
@@ -6501,14 +6502,14 @@ describe("CLIEngine", () => {
                 ]);
             });
 
-            it("'executeOnFiles()' with 'node_modules/myconf/foo/test.js' should NOT use the override entry.", () => {
+            it("'executeOnFiles()' with 'node_modules/myconf/foo/test.js' should NOT use the override entry.", async () => {
                 const engine = new CLIEngine({
                     configFile: "node_modules/myconf/.eslintrc.json",
                     cwd: getPath(),
                     ignore: false,
                     useEslintrc: false
                 });
-                const { results } = engine.executeOnFiles("node_modules/myconf/foo/test.js");
+                const { results } = await engine.executeOnFiles("node_modules/myconf/foo/test.js");
 
                 // Expected to be no errors because the file doesn't match to `$CWD/foo/*.js`.
                 assert.deepStrictEqual(results, [
@@ -6549,14 +6550,14 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'executeOnFiles()' with 'foo/test.js' should NOT use the override entry.", () => {
+            it("'executeOnFiles()' with 'foo/test.js' should NOT use the override entry.", async () => {
                 const engine = new CLIEngine({
                     configFile: "node_modules/myconf/.eslintrc.json",
                     cwd: getPath(),
                     ignore: false,
                     useEslintrc: false
                 });
-                const { results } = engine.executeOnFiles("foo/test.js");
+                const { results } = await engine.executeOnFiles("foo/test.js");
 
                 // Expected to be no errors because the file matches to `$CWD/foo/*.js`.
                 assert.deepStrictEqual(results, [
@@ -6573,14 +6574,14 @@ describe("CLIEngine", () => {
                 ]);
             });
 
-            it("'executeOnFiles()' with 'node_modules/myconf/foo/test.js' should use the override entry.", () => {
+            it("'executeOnFiles()' with 'node_modules/myconf/foo/test.js' should use the override entry.", async () => {
                 const engine = new CLIEngine({
                     configFile: "node_modules/myconf/.eslintrc.json",
                     cwd: getPath(),
                     ignore: false,
                     useEslintrc: false
                 });
-                const { results } = engine.executeOnFiles("node_modules/myconf/foo/test.js");
+                const { results } = await engine.executeOnFiles("node_modules/myconf/foo/test.js");
 
                 // Expected to be an 'eqeqeq' error because the file doesn't match to `$CWD/foo/*.js`.
                 assert.deepStrictEqual(results, [
@@ -6629,13 +6630,13 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'executeOnFiles()' with '**/*.js' should iterate 'node_modules/myconf/foo/test.js' but not 'foo/test.js'.", () => {
+            it("'executeOnFiles()' with '**/*.js' should iterate 'node_modules/myconf/foo/test.js' but not 'foo/test.js'.", async () => {
                 const engine = new CLIEngine({
                     configFile: "node_modules/myconf/.eslintrc.json",
                     cwd: getPath(),
                     useEslintrc: false
                 });
-                const files = engine.executeOnFiles("**/*.js")
+                const files = (await engine.executeOnFiles("**/*.js"))
                     .results
                     .map(r => r.filePath)
                     .sort();
@@ -6653,13 +6654,13 @@ describe("CLIEngine", () => {
 
         /**
          * Verify thrown errors.
-         * @param {() => void} f The function to run and throw.
+         * @param {() => Promise<void> | void} f The function to run and throw.
          * @param {Record<string, any>} props The properties to verify.
          * @returns {void}
          */
-        function assertThrows(f, props) {
+        async function assertThrows(f, props) {
             try {
-                f();
+                await f();
             } catch (error) {
                 for (const [key, value] of Object.entries(props)) {
                     assert.deepStrictEqual(error[key], value, key);
@@ -6696,10 +6697,10 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'executeOnFiles()' should NOT throw plugin-conflict error. (Load the plugin from the base directory of the entry config file.)", () => {
+            it("'executeOnFiles()' should NOT throw plugin-conflict error. (Load the plugin from the base directory of the entry config file.)", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
-                engine.executeOnFiles("test.js");
+                await engine.executeOnFiles("test.js");
             });
         });
 
@@ -6727,10 +6728,10 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'executeOnFiles()' should NOT throw plugin-conflict error. (Load the plugin from the base directory of the entry config file.)", () => {
+            it("'executeOnFiles()' should NOT throw plugin-conflict error. (Load the plugin from the base directory of the entry config file.)", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
-                engine.executeOnFiles("test.js");
+                await engine.executeOnFiles("test.js");
             });
         });
 
@@ -6752,10 +6753,10 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'executeOnFiles()' should NOT throw plugin-conflict error. (Load the plugin from the base directory of the entry config file, but there are two entry config files, but node_modules directory is unique.)", () => {
+            it("'executeOnFiles()' should NOT throw plugin-conflict error. (Load the plugin from the base directory of the entry config file, but there are two entry config files, but node_modules directory is unique.)", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
-                engine.executeOnFiles("subdir/test.js");
+                await engine.executeOnFiles("subdir/test.js");
             });
         });
 
@@ -6778,11 +6779,11 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'executeOnFiles()' should throw plugin-conflict error. (Load the plugin from the base directory of the entry config file, but there are two entry config files.)", () => {
+            it("'executeOnFiles()' should throw plugin-conflict error. (Load the plugin from the base directory of the entry config file, but there are two entry config files.)", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
 
-                assertThrows(
-                    () => engine.executeOnFiles("subdir/test.js"),
+                await assertThrows(
+                    async () => await engine.executeOnFiles("subdir/test.js"),
                     {
                         message: `Plugin "foo" was conflicted between "subdir${path.sep}.eslintrc.json" and ".eslintrc.json".`,
                         messageTemplate: "plugin-conflict",
@@ -6822,13 +6823,13 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'executeOnFiles()' should NOT throw plugin-conflict error. (Load the plugin from the base directory of the entry config file, but there are two entry config files, but node_modules directory is unique.)", () => {
+            it("'executeOnFiles()' should NOT throw plugin-conflict error. (Load the plugin from the base directory of the entry config file, but there are two entry config files, but node_modules directory is unique.)", async () => {
                 const engine = new CLIEngine({
                     cwd: getPath(),
                     configFile: "node_modules/mine/.eslintrc.json"
                 });
 
-                engine.executeOnFiles("test.js");
+                await engine.executeOnFiles("test.js");
             });
         });
 
@@ -6851,14 +6852,14 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'executeOnFiles()' should throw plugin-conflict error. (Load the plugin from the base directory of the entry config file, but there are two entry config files.)", () => {
+            it("'executeOnFiles()' should throw plugin-conflict error. (Load the plugin from the base directory of the entry config file, but there are two entry config files.)", async () => {
                 const engine = new CLIEngine({
                     cwd: getPath(),
                     configFile: "node_modules/mine/.eslintrc.json"
                 });
 
-                assertThrows(
-                    () => engine.executeOnFiles("test.js"),
+                await assertThrows(
+                    async () => await engine.executeOnFiles("test.js"),
                     {
                         message: "Plugin \"foo\" was conflicted between \"--config\" and \".eslintrc.json\".",
                         messageTemplate: "plugin-conflict",
@@ -6895,13 +6896,13 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'executeOnFiles()' should NOT throw plugin-conflict error. (Load the plugin from both CWD and the base directory of the entry config file, but node_modules directory is unique.)", () => {
+            it("'executeOnFiles()' should NOT throw plugin-conflict error. (Load the plugin from both CWD and the base directory of the entry config file, but node_modules directory is unique.)", async () => {
                 const engine = new CLIEngine({
                     cwd: getPath(),
                     plugins: ["foo"]
                 });
 
-                engine.executeOnFiles("subdir/test.js");
+                await engine.executeOnFiles("subdir/test.js");
             });
         });
 
@@ -6921,14 +6922,14 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'executeOnFiles()' should throw plugin-conflict error. (Load the plugin from both CWD and the base directory of the entry config file.)", () => {
+            it("'executeOnFiles()' should throw plugin-conflict error. (Load the plugin from both CWD and the base directory of the entry config file.)", async () => {
                 const engine = new CLIEngine({
                     cwd: getPath(),
                     plugins: ["foo"]
                 });
 
-                assertThrows(
-                    () => engine.executeOnFiles("subdir/test.js"),
+                await assertThrows(
+                    async () => await engine.executeOnFiles("subdir/test.js"),
                     {
                         message: `Plugin "foo" was conflicted between "CLIOptions" and "subdir${path.sep}.eslintrc.json".`,
                         messageTemplate: "plugin-conflict",
@@ -6969,13 +6970,13 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'executeOnFiles()' should NOT throw plugin-conflict error. (Load the plugin from '--resolve-plugins-relative-to'.)", () => {
+            it("'executeOnFiles()' should NOT throw plugin-conflict error. (Load the plugin from '--resolve-plugins-relative-to'.)", async () => {
                 const engine = new CLIEngine({
                     cwd: getPath(),
                     resolvePluginsRelativeTo: getPath()
                 });
 
-                engine.executeOnFiles("subdir/test.js");
+                await engine.executeOnFiles("subdir/test.js");
             });
         });
 
@@ -6999,9 +7000,9 @@ describe("CLIEngine", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'executeOnFiles()' should NOT throw plugin-conflict error. (Load the plugin from the base directory of the entry config file for each target file. Not related to each other.)", () => {
+            it("'executeOnFiles()' should NOT throw plugin-conflict error. (Load the plugin from the base directory of the entry config file for each target file. Not related to each other.)", async () => {
                 const engine = new CLIEngine({ cwd: getPath() });
-                const { results } = engine.executeOnFiles("*/test.js");
+                const { results } = await engine.executeOnFiles("*/test.js");
 
                 assert.strictEqual(results.length, 2);
             });

--- a/tests/lib/cli-engine/lint-result-cache.js
+++ b/tests/lib/cli-engine/lint-result-cache.js
@@ -34,7 +34,7 @@ describe("LintResultCache", () => {
         fakeErrorResults,
         fakeErrorResultsAutofix;
 
-    before(() => {
+    before(async () => {
         sandbox = sinon.createSandbox();
         hashStub = sandbox.stub();
 
@@ -49,15 +49,15 @@ describe("LintResultCache", () => {
         });
 
         // Get results without autofixing...
-        fakeErrorResults = cliEngine.executeOnFiles([
+        fakeErrorResults = (await cliEngine.executeOnFiles([
             path.join(fixturePath, "test-with-errors.js")
-        ]).results[0];
+        ])).results[0];
 
         // ...and with autofixing
         shouldFix = true;
-        fakeErrorResultsAutofix = cliEngine.executeOnFiles([
+        fakeErrorResultsAutofix = (await cliEngine.executeOnFiles([
             path.join(fixturePath, "test-with-errors.js")
-        ]).results[0];
+        ])).results[0];
 
         // Set up LintResultCache with fake fileEntryCache module
         LintResultCache = proxyquire(

--- a/tests/lib/linter/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/linter/code-path-analysis/code-path-analyzer.js
@@ -64,7 +64,7 @@ describe("CodePathAnalyzer", () => {
     describe("interface of code paths", () => {
         let actual = [];
 
-        beforeEach(() => {
+        beforeEach(async () => {
             actual = [];
             linter.defineRule("test", {
                 create: () => ({
@@ -73,7 +73,7 @@ describe("CodePathAnalyzer", () => {
                     }
                 })
             });
-            linter.verify(
+            await linter.verify(
                 "function foo(a) { if (a) return 0; else throw new Error(); }",
                 { rules: { test: 2 } }
             );
@@ -137,7 +137,7 @@ describe("CodePathAnalyzer", () => {
             assert(actual[1].thrownSegments[0] instanceof CodePathSegment);
         });
 
-        it("should have `currentSegments` as CodePathSegment[]", () => {
+        it("should have `currentSegments` as CodePathSegment[]", async () => {
             assert(Array.isArray(actual[0].currentSegments));
             assert(Array.isArray(actual[1].currentSegments));
             assert(actual[0].currentSegments.length === 0);
@@ -163,7 +163,7 @@ describe("CodePathAnalyzer", () => {
                     };
                 }
             });
-            linter.verify(
+            await linter.verify(
                 "function foo(a) { if (a) return 0; else throw new Error(); }",
                 { rules: { test: 2 } }
             );
@@ -173,7 +173,7 @@ describe("CodePathAnalyzer", () => {
     describe("interface of code path segments", () => {
         let actual = [];
 
-        beforeEach(() => {
+        beforeEach(async () => {
             actual = [];
             linter.defineRule("test", {
                 create: () => ({
@@ -182,7 +182,7 @@ describe("CodePathAnalyzer", () => {
                     }
                 })
             });
-            linter.verify(
+            await linter.verify(
                 "function foo(a) { if (a) return 0; else throw new Error(); }",
                 { rules: { test: 2 } }
             );
@@ -260,7 +260,7 @@ describe("CodePathAnalyzer", () => {
     });
 
     describe("onCodePathStart", () => {
-        it("should be fired at the head of programs/functions", () => {
+        it("should be fired at the head of programs/functions", async () => {
             let count = 0;
             let lastCodePathNodeType = null;
 
@@ -295,7 +295,7 @@ describe("CodePathAnalyzer", () => {
                     }
                 })
             });
-            linter.verify(
+            await linter.verify(
                 "foo(); function foo() {} var foo = function() {}; var foo = () => {};",
                 { rules: { test: 2 }, env: { es6: true } }
             );
@@ -305,7 +305,7 @@ describe("CodePathAnalyzer", () => {
     });
 
     describe("onCodePathEnd", () => {
-        it("should be fired at the end of programs/functions", () => {
+        it("should be fired at the end of programs/functions", async () => {
             let count = 0;
             let lastNodeType = null;
 
@@ -340,7 +340,7 @@ describe("CodePathAnalyzer", () => {
                     }
                 })
             });
-            linter.verify(
+            await linter.verify(
                 "foo(); function foo() {} var foo = function() {}; var foo = () => {};",
                 { rules: { test: 2 }, env: { es6: true } }
             );
@@ -350,7 +350,7 @@ describe("CodePathAnalyzer", () => {
     });
 
     describe("onCodePathSegmentStart", () => {
-        it("should be fired at the head of programs/functions for the initial segment", () => {
+        it("should be fired at the head of programs/functions for the initial segment", async () => {
             let count = 0;
             let lastCodePathNodeType = null;
 
@@ -385,7 +385,7 @@ describe("CodePathAnalyzer", () => {
                     }
                 })
             });
-            linter.verify(
+            await linter.verify(
                 "foo(); function foo() {} var foo = function() {}; var foo = () => {};",
                 { rules: { test: 2 }, env: { es6: true } }
             );
@@ -395,7 +395,7 @@ describe("CodePathAnalyzer", () => {
     });
 
     describe("onCodePathSegmentEnd", () => {
-        it("should be fired at the end of programs/functions for the final segment", () => {
+        it("should be fired at the end of programs/functions for the final segment", async () => {
             let count = 0;
             let lastNodeType = null;
 
@@ -430,7 +430,7 @@ describe("CodePathAnalyzer", () => {
                     }
                 })
             });
-            linter.verify(
+            await linter.verify(
                 "foo(); function foo() {} var foo = function() {}; var foo = () => {};",
                 { rules: { test: 2 }, env: { es6: true } }
             );
@@ -440,7 +440,7 @@ describe("CodePathAnalyzer", () => {
     });
 
     describe("onCodePathSegmentLoop", () => {
-        it("should be fired in `while` loops", () => {
+        it("should be fired in `while` loops", async () => {
             let count = 0;
 
             linter.defineRule("test", {
@@ -453,7 +453,7 @@ describe("CodePathAnalyzer", () => {
                     }
                 })
             });
-            linter.verify(
+            await linter.verify(
                 "while (a) { foo(); }",
                 { rules: { test: 2 } }
             );
@@ -461,7 +461,7 @@ describe("CodePathAnalyzer", () => {
             assert(count === 1);
         });
 
-        it("should be fired in `do-while` loops", () => {
+        it("should be fired in `do-while` loops", async () => {
             let count = 0;
 
             linter.defineRule("test", {
@@ -474,7 +474,7 @@ describe("CodePathAnalyzer", () => {
                     }
                 })
             });
-            linter.verify(
+            await linter.verify(
                 "do { foo(); } while (a);",
                 { rules: { test: 2 } }
             );
@@ -482,7 +482,7 @@ describe("CodePathAnalyzer", () => {
             assert(count === 1);
         });
 
-        it("should be fired in `for` loops", () => {
+        it("should be fired in `for` loops", async () => {
             let count = 0;
 
             linter.defineRule("test", {
@@ -502,7 +502,7 @@ describe("CodePathAnalyzer", () => {
                     }
                 })
             });
-            linter.verify(
+            await linter.verify(
                 "for (var i = 0; i < 10; ++i) { foo(); }",
                 { rules: { test: 2 } }
             );
@@ -510,7 +510,7 @@ describe("CodePathAnalyzer", () => {
             assert(count === 2);
         });
 
-        it("should be fired in `for-in` loops", () => {
+        it("should be fired in `for-in` loops", async () => {
             let count = 0;
 
             linter.defineRule("test", {
@@ -530,7 +530,7 @@ describe("CodePathAnalyzer", () => {
                     }
                 })
             });
-            linter.verify(
+            await linter.verify(
                 "for (var k in obj) { foo(); }",
                 { rules: { test: 2 } }
             );
@@ -538,7 +538,7 @@ describe("CodePathAnalyzer", () => {
             assert(count === 2);
         });
 
-        it("should be fired in `for-of` loops", () => {
+        it("should be fired in `for-of` loops", async () => {
             let count = 0;
 
             linter.defineRule("test", {
@@ -558,7 +558,7 @@ describe("CodePathAnalyzer", () => {
                     }
                 })
             });
-            linter.verify(
+            await linter.verify(
                 "for (var x of xs) { foo(); }",
                 { rules: { test: 2 }, env: { es6: true } }
             );
@@ -567,12 +567,12 @@ describe("CodePathAnalyzer", () => {
         });
     });
 
-    describe("completed code paths are correct", () => {
+    describe("completed code paths are correct", async () => {
         const testDataDir = path.join(__dirname, "../../../fixtures/code-path-analysis/");
         const testDataFiles = fs.readdirSync(testDataDir);
 
-        testDataFiles.forEach(file => {
-            it(file, () => {
+        for (const file of testDataFiles) {
+            it(file, async () => {
                 const source = fs.readFileSync(path.join(testDataDir, file), { encoding: "utf8" });
                 const expected = getExpectedDotArrows(source);
                 const actual = [];
@@ -586,7 +586,7 @@ describe("CodePathAnalyzer", () => {
                         }
                     })
                 });
-                const messages = linter.verify(source, {
+                const messages = await linter.verify(source, {
                     parserOptions: { ecmaVersion: 2022 },
                     rules: { test: 2 }
                 });
@@ -598,6 +598,6 @@ describe("CodePathAnalyzer", () => {
                     assert.strictEqual(actual[i], expected[i]);
                 }
             });
-        });
+        }
     });
 });

--- a/tests/lib/linter/code-path-analysis/code-path.js
+++ b/tests/lib/linter/code-path-analysis/code-path.js
@@ -22,7 +22,7 @@ const linter = new Linter();
  * @param {string} code A source code.
  * @returns {CodePath[]} A list of created code paths.
  */
-function parseCodePaths(code) {
+async function parseCodePaths(code) {
     const retv = [];
 
     linter.defineRule("test", {
@@ -33,7 +33,7 @@ function parseCodePaths(code) {
         })
     });
 
-    linter.verify(code, {
+    await linter.verify(code, {
         rules: { test: 2 },
         parserOptions: { ecmaVersion: "latest" }
     });
@@ -79,38 +79,38 @@ describe("CodePathAnalyzer", () => {
      */
     /*
      * it.only("test", () => {
-     *     const codePaths = parseCodePaths("class Foo { a = () => b }");
+     *     const codePaths = await parseCodePaths("class Foo { a = () => b }");
      * });
      */
 
     describe("CodePath#origin", () => {
 
-        it("should be 'program' when code path starts at root node", () => {
-            const codePath = parseCodePaths("foo(); bar(); baz();")[0];
+        it("should be 'program' when code path starts at root node", async () => {
+            const codePath = (await parseCodePaths("foo(); bar(); baz();"))[0];
 
             assert.strictEqual(codePath.origin, "program");
         });
 
-        it("should be 'function' when code path starts inside a function", () => {
-            const codePath = parseCodePaths("function foo() {}")[1];
+        it("should be 'function' when code path starts inside a function", async () => {
+            const codePath = (await parseCodePaths("function foo() {}"))[1];
 
             assert.strictEqual(codePath.origin, "function");
         });
 
-        it("should be 'function' when code path starts inside an arrow function", () => {
-            const codePath = parseCodePaths("let foo = () => {}")[1];
+        it("should be 'function' when code path starts inside an arrow function", async () => {
+            const codePath = (await parseCodePaths("let foo = () => {}"))[1];
 
             assert.strictEqual(codePath.origin, "function");
         });
 
-        it("should be 'class-field-initializer' when code path starts inside a class field initializer", () => {
-            const codePath = parseCodePaths("class Foo { a=1; }")[1];
+        it("should be 'class-field-initializer' when code path starts inside a class field initializer", async () => {
+            const codePath = (await parseCodePaths("class Foo { a=1; }"))[1];
 
             assert.strictEqual(codePath.origin, "class-field-initializer");
         });
 
-        it("should be 'class-static-block' when code path starts inside a class static block", () => {
-            const codePath = parseCodePaths("class Foo { static { this.a=1; } }")[1];
+        it("should be 'class-static-block' when code path starts inside a class static block", async () => {
+            const codePath = (await parseCodePaths("class Foo { static { this.a=1; } }"))[1];
 
             assert.strictEqual(codePath.origin, "class-static-block");
         });
@@ -120,8 +120,8 @@ describe("CodePathAnalyzer", () => {
 
         describe("should traverse segments from the first to the end:", () => {
             /* eslint-disable internal-rules/multiline-comment-style -- Commenting out */
-            it("simple", () => {
-                const codePath = parseCodePaths("foo(); bar(); baz();")[0];
+            it("simple", async () => {
+                const codePath = (await parseCodePaths("foo(); bar(); baz();"))[0];
                 const order = getOrderOfTraversing(codePath);
 
                 assert.deepStrictEqual(order, ["s1_1"]);
@@ -137,8 +137,8 @@ describe("CodePathAnalyzer", () => {
                 */
             });
 
-            it("if", () => {
-                const codePath = parseCodePaths("if (a) foo(); else bar(); baz();")[0];
+            it("if", async () => {
+                const codePath = (await parseCodePaths("if (a) foo(); else bar(); baz();"))[0];
                 const order = getOrderOfTraversing(codePath);
 
                 assert.deepStrictEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4"]);
@@ -158,8 +158,8 @@ describe("CodePathAnalyzer", () => {
                 */
             });
 
-            it("switch", () => {
-                const codePath = parseCodePaths("switch (a) { case 0: foo(); break; case 1: bar(); } baz();")[0];
+            it("switch", async () => {
+                const codePath = (await parseCodePaths("switch (a) { case 0: foo(); break; case 1: bar(); } baz();"))[0];
                 const order = getOrderOfTraversing(codePath);
 
                 assert.deepStrictEqual(order, ["s1_1", "s1_2", "s1_4", "s1_5", "s1_6"]);
@@ -183,8 +183,8 @@ describe("CodePathAnalyzer", () => {
                 */
             });
 
-            it("while", () => {
-                const codePath = parseCodePaths("while (a) foo(); bar();")[0];
+            it("while", async () => {
+                const codePath = (await parseCodePaths("while (a) foo(); bar();"))[0];
                 const order = getOrderOfTraversing(codePath);
 
                 assert.deepStrictEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4"]);
@@ -203,8 +203,8 @@ describe("CodePathAnalyzer", () => {
                 */
             });
 
-            it("for", () => {
-                const codePath = parseCodePaths("for (var i = 0; i < 10; ++i) foo(i); bar();")[0];
+            it("for", async () => {
+                const codePath = (await parseCodePaths("for (var i = 0; i < 10; ++i) foo(i); bar();"))[0];
                 const order = getOrderOfTraversing(codePath);
 
                 assert.deepStrictEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4", "s1_5"]);
@@ -224,8 +224,8 @@ describe("CodePathAnalyzer", () => {
                 */
             });
 
-            it("for-in", () => {
-                const codePath = parseCodePaths("for (var key in obj) foo(key); bar();")[0];
+            it("for-in", async () => {
+                const codePath = (await parseCodePaths("for (var key in obj) foo(key); bar();"))[0];
                 const order = getOrderOfTraversing(codePath);
 
                 assert.deepStrictEqual(order, ["s1_1", "s1_3", "s1_2", "s1_4", "s1_5"]);
@@ -247,8 +247,8 @@ describe("CodePathAnalyzer", () => {
                 */
             });
 
-            it("try-catch", () => {
-                const codePath = parseCodePaths("try { foo(); } catch (e) { bar(); } baz();")[0];
+            it("try-catch", async () => {
+                const codePath = (await parseCodePaths("try { foo(); } catch (e) { bar(); } baz();"))[0];
                 const order = getOrderOfTraversing(codePath);
 
                 assert.deepStrictEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4"]);
@@ -270,8 +270,8 @@ describe("CodePathAnalyzer", () => {
             });
         });
 
-        it("should traverse segments from `options.first` to `options.last`.", () => {
-            const codePath = parseCodePaths("if (a) { if (b) { foo(); } bar(); } else { out1(); } out2();")[0];
+        it("should traverse segments from `options.first` to `options.last`.", async () => {
+            const codePath = (await parseCodePaths("if (a) { if (b) { foo(); } bar(); } else { out1(); } out2();"))[0];
             const order = getOrderOfTraversing(codePath, {
                 first: codePath.initialSegment.nextSegments[0],
                 last: codePath.initialSegment.nextSegments[0].nextSegments[1]
@@ -298,8 +298,8 @@ describe("CodePathAnalyzer", () => {
             */
         });
 
-        it("should stop immediately when 'controller.break()' was called.", () => {
-            const codePath = parseCodePaths("if (a) { if (b) { foo(); } bar(); } else { out1(); } out2();")[0];
+        it("should stop immediately when 'controller.break()' was called.", async () => {
+            const codePath = (await parseCodePaths("if (a) { if (b) { foo(); } bar(); } else { out1(); } out2();"))[0];
             const order = getOrderOfTraversing(codePath, null, (segment, controller) => {
                 if (segment.id === "s1_2") {
                     controller.break();
@@ -327,8 +327,8 @@ describe("CodePathAnalyzer", () => {
             */
         });
 
-        it("should skip the current branch when 'controller.skip()' was called.", () => {
-            const codePath = parseCodePaths("if (a) { if (b) { foo(); } bar(); } else { out1(); } out2();")[0];
+        it("should skip the current branch when 'controller.skip()' was called.", async () => {
+            const codePath = (await parseCodePaths("if (a) { if (b) { foo(); } bar(); } else { out1(); } out2();"))[0];
             const order = getOrderOfTraversing(codePath, null, (segment, controller) => {
                 if (segment.id === "s1_2") {
                     controller.skip();

--- a/tests/lib/linter/rules.js
+++ b/tests/lib/linter/rules.js
@@ -54,11 +54,11 @@ describe("rules", () => {
 
 
     describe("when a rule is not found", () => {
-        it("should report a linting error if the rule is unknown", () => {
+        it("should report a linting error if the rule is unknown", async () => {
 
             const linter = new Linter();
 
-            const problems = linter.verify("foo", { rules: { "test-rule": "error" } });
+            const problems = await linter.verify("foo", { rules: { "test-rule": "error" } });
 
             assert.lengthOf(problems, 1);
             assert.strictEqual(problems[0].message, "Definition for rule 'test-rule' was not found.");
@@ -69,9 +69,9 @@ describe("rules", () => {
         });
 
 
-        it("should report a linting error that lists replacements if a rule is known to have been replaced", () => {
+        it("should report a linting error that lists replacements if a rule is known to have been replaced", async () => {
             const linter = new Linter();
-            const problems = linter.verify("foo", { rules: { "no-arrow-condition": "error" } });
+            const problems = await linter.verify("foo", { rules: { "no-arrow-condition": "error" } });
 
             assert.lengthOf(problems, 1);
             assert.strictEqual(

--- a/tests/lib/rule-tester/flat-rule-tester.js
+++ b/tests/lib/rule-tester/flat-rule-tester.js
@@ -152,13 +152,13 @@ describe("FlatRuleTester", () => {
             assert.throw(setConfig(true), errorMessage);
         });
 
-        it("should pass-through the globals config to the tester then to the to rule", () => {
+        it("should pass-through the globals config to the tester then to the to rule", async () => {
             const config = { languageOptions: { sourceType: "script", globals: { test: true } } };
 
             FlatRuleTester.setDefaultConfig(config);
             ruleTester = new FlatRuleTester();
 
-            ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
+            await ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
                 valid: [
                     "var test = 'foo'",
                     "var test2 = test"
@@ -167,7 +167,7 @@ describe("FlatRuleTester", () => {
             });
         });
 
-        it("should throw an error if node.start is accessed with parser in default config", () => {
+        it("should throw an error if node.start is accessed with parser in default config", async () => {
             const enhancedParser = require("../../fixtures/parsers/enhanced-parser");
 
             FlatRuleTester.setDefaultConfig({
@@ -193,12 +193,12 @@ describe("FlatRuleTester", () => {
                 }
             };
 
-            assert.throws(() => {
-                ruleTester.run("uses-start-end", usesStartEndRule, {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("uses-start-end", usesStartEndRule, {
                     valid: ["foo(a, b)"],
                     invalid: []
                 });
-            }, "Use node.range[0] instead of node.start");
+            }, /Use node\.range\[0\] instead of node\.start/u);
         });
 
     });
@@ -217,8 +217,8 @@ describe("FlatRuleTester", () => {
                     ruleTester = new FlatRuleTester();
                 });
 
-                it("is called by exclusive tests", () => {
-                    ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                it("is called by exclusive tests", async () => {
+                    await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                         valid: [{
                             code: "const notVar = 42;",
                             only: true
@@ -243,8 +243,8 @@ describe("FlatRuleTester", () => {
                     ruleTester = new FlatRuleTester();
                 });
 
-                it("is called by tests with `only` set", () => {
-                    ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                it("is called by tests with `only` set", async () => {
+                    await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                         valid: [{
                             code: "const notVar = 42;",
                             only: true
@@ -277,8 +277,8 @@ describe("FlatRuleTester", () => {
                     ruleTester = new FlatRuleTester();
                 });
 
-                it("is called by tests with `only` set", () => {
-                    ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                it("is called by tests with `only` set", async () => {
+                    await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                         valid: [{
                             code: "const notVar = 42;",
                             only: true
@@ -311,9 +311,9 @@ describe("FlatRuleTester", () => {
                     ruleTester = new FlatRuleTester();
                 });
 
-                it("throws an error recommending overriding `itOnly`", () => {
-                    assert.throws(() => {
-                        ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                it("throws an error recommending overriding `itOnly`", async () => {
+                    await nodeAssert.rejects(async () => {
+                        await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                             valid: [{
                                 code: "const notVar = 42;",
                                 only: true
@@ -355,9 +355,9 @@ describe("FlatRuleTester", () => {
                     ruleTester = new FlatRuleTester();
                 });
 
-                it("throws an error explaining that the current test framework does not support `only`", () => {
-                    assert.throws(() => {
-                        ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                it("throws an error explaining that the current test framework does not support `only`", async () => {
+                    await nodeAssert.rejects(async () => {
+                        await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                             valid: [{
                                 code: "const notVar = 42;",
                                 only: true
@@ -396,8 +396,8 @@ describe("FlatRuleTester", () => {
                 ruleTester = new FlatRuleTester();
             });
 
-            it("isn't called for normal tests", () => {
-                ruleTester.run(ruleName, rule, {
+            it("isn't called for normal tests", async () => {
+                await ruleTester.run(ruleName, rule, {
                     valid: ["const notVar = 42;"],
                     invalid: []
                 });
@@ -405,7 +405,7 @@ describe("FlatRuleTester", () => {
                 sinon.assert.notCalled(spyRuleTesterItOnly);
             });
 
-            it("calls it or itOnly for every test case", () => {
+            it("calls it or itOnly for every test case", async () => {
 
                 /*
                  * `RuleTester` doesn't implement test case exclusivity itself.
@@ -414,7 +414,7 @@ describe("FlatRuleTester", () => {
                  * instead of the regular `it()` function.
                  */
 
-                ruleTester.run(ruleName, rule, {
+                await ruleTester.run(ruleName, rule, {
                     valid: [
                         "const valid = 42;",
                         {
@@ -463,8 +463,8 @@ describe("FlatRuleTester", () => {
         });
     });
 
-    it("should not throw an error when everything passes", () => {
-        ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should not throw an error when everything passes", async () => {
+        await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
             valid: [
                 "Eval(foo)"
             ],
@@ -474,10 +474,10 @@ describe("FlatRuleTester", () => {
         });
     });
 
-    it("should throw correct error when valid code is invalid and enables other core rule", () => {
+    it("should throw correct error when valid code is invalid and enables other core rule", async () => {
 
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "/*eslint semi: 2*/ eval(foo);"
                 ],
@@ -488,10 +488,10 @@ describe("FlatRuleTester", () => {
         }, /Should have no errors but had 1/u);
     });
 
-    it("should throw an error when valid code is invalid", () => {
+    it("should throw an error when valid code is invalid", async () => {
 
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "eval(foo)"
                 ],
@@ -502,10 +502,10 @@ describe("FlatRuleTester", () => {
         }, /Should have no errors but had 1/u);
     });
 
-    it("should throw an error when valid code is invalid", () => {
+    it("should throw an error when valid code is invalid", async () => {
 
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     { code: "eval(foo)" }
                 ],
@@ -516,10 +516,10 @@ describe("FlatRuleTester", () => {
         }, /Should have no errors but had 1/u);
     });
 
-    it("should throw an error if invalid code is valid", () => {
+    it("should throw an error if invalid code is valid", async () => {
 
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
                 ],
@@ -530,9 +530,9 @@ describe("FlatRuleTester", () => {
         }, /Should have 1 error but had 0/u);
     });
 
-    it("should throw an error when the error message is wrong", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the error message is wrong", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
 
                 // Only the invalid test matters here
                 valid: [
@@ -542,12 +542,12 @@ describe("FlatRuleTester", () => {
                     { code: "var foo = bar;", errors: [{ message: "Bad error message." }] }
                 ]
             });
-        }, assertErrorMatches("Bad var.", "Bad error message."));
+        }, assertErrorMatches(/"Bad var./u, /Bad error message./u));
     });
 
-    it("should throw an error when the error message regex does not match", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the error message regex does not match", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [],
                 invalid: [
                     { code: "var foo = bar;", errors: [{ message: /Bad error message/u }] }
@@ -556,9 +556,9 @@ describe("FlatRuleTester", () => {
         }, /Expected 'Bad var.' to match \/Bad error message\//u);
     });
 
-    it("should throw an error when the error is not a supported type", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the error is not a supported type", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
 
                 // Only the invalid test matters here
                 valid: [
@@ -571,9 +571,9 @@ describe("FlatRuleTester", () => {
         }, /Error should be a string, object, or RegExp/u);
     });
 
-    it("should throw an error when any of the errors is not a supported type", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when any of the errors is not a supported type", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
 
                 // Only the invalid test matters here
                 valid: [
@@ -586,9 +586,9 @@ describe("FlatRuleTester", () => {
         }, /Error should be a string, object, or RegExp/u);
     });
 
-    it("should throw an error when the error is a string and it does not match error message", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the error is a string and it does not match error message", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
 
                 // Only the invalid test matters here
                 valid: [
@@ -598,12 +598,12 @@ describe("FlatRuleTester", () => {
                     { code: "var foo = bar;", errors: ["Bad error message."] }
                 ]
             });
-        }, assertErrorMatches("Bad var.", "Bad error message."));
+        }, assertErrorMatches(/Bad var./u, /Bad error message./u));
     });
 
-    it("should throw an error when the error is a string and it does not match error message", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the error is a string and it does not match error message", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
 
                 valid: [
                 ],
@@ -614,8 +614,8 @@ describe("FlatRuleTester", () => {
         }, /Expected 'Bad var.' to match \/Bad error message\//u);
     });
 
-    it("should not throw an error when the error is a string and it matches error message", () => {
-        ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should not throw an error when the error is a string and it matches error message", async () => {
+        await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
 
             // Only the invalid test matters here
             valid: [
@@ -627,8 +627,8 @@ describe("FlatRuleTester", () => {
         });
     });
 
-    it("should not throw an error when the error is a regex and it matches error message", () => {
-        ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should not throw an error when the error is a regex and it matches error message", async () => {
+        await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
             valid: [],
             invalid: [
                 { code: "var foo = bar;", output: " foo = bar;", errors: [/^Bad var/u] }
@@ -636,9 +636,9 @@ describe("FlatRuleTester", () => {
         });
     });
 
-    it("should throw an error when the error is an object with an unknown property name", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the error is an object with an unknown property name", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
                 ],
@@ -649,9 +649,9 @@ describe("FlatRuleTester", () => {
         }, /Invalid error property name 'Message'/u);
     });
 
-    it("should throw an error when any of the errors is an object with an unknown property name", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when any of the errors is an object with an unknown property name", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
                 ],
@@ -668,8 +668,8 @@ describe("FlatRuleTester", () => {
         }, /Invalid error property name 'typo'/u);
     });
 
-    it("should not throw an error when the error is a regex in an object and it matches error message", () => {
-        ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should not throw an error when the error is a regex in an object and it matches error message", async () => {
+        await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
             valid: [],
             invalid: [
                 { code: "var foo = bar;", output: " foo = bar;", errors: [{ message: /^Bad var/u }] }
@@ -677,9 +677,9 @@ describe("FlatRuleTester", () => {
         });
     });
 
-    it("should throw an error when the expected output doesn't match", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the expected output doesn't match", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
                 ],
@@ -690,7 +690,7 @@ describe("FlatRuleTester", () => {
         }, /Output is incorrect/u);
     });
 
-    it("should use strict equality to compare output", () => {
+    it("should use strict equality to compare output", async () => {
         const replaceProgramWith5Rule = {
             meta: {
                 fixable: "code"
@@ -704,15 +704,15 @@ describe("FlatRuleTester", () => {
         };
 
         // Should not throw.
-        ruleTester.run("foo", replaceProgramWith5Rule, {
+        await ruleTester.run("foo", replaceProgramWith5Rule, {
             valid: [],
             invalid: [
                 { code: "var foo = bar;", output: "5", errors: 1 }
             ]
         });
 
-        assert.throws(() => {
-            ruleTester.run("foo", replaceProgramWith5Rule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", replaceProgramWith5Rule, {
                 valid: [],
                 invalid: [
                     { code: "var foo = bar;", output: 5, errors: 1 }
@@ -721,9 +721,9 @@ describe("FlatRuleTester", () => {
         }, /Output is incorrect/u);
     });
 
-    it("should throw an error when the expected output doesn't match and errors is just a number", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the expected output doesn't match and errors is just a number", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
                 ],
@@ -734,8 +734,8 @@ describe("FlatRuleTester", () => {
         }, /Output is incorrect/u);
     });
 
-    it("should not throw an error when the expected output is null and no errors produce output", () => {
-        ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should not throw an error when the expected output is null and no errors produce output", async () => {
+        await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
             valid: [
                 "bar = baz;"
             ],
@@ -746,9 +746,9 @@ describe("FlatRuleTester", () => {
         });
     });
 
-    it("should throw an error when the expected output is null and problems produce output", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the expected output is null and problems produce output", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
                 ],
@@ -758,8 +758,8 @@ describe("FlatRuleTester", () => {
             });
         }, /Expected no autofixes to be suggested/u);
 
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
                 ],
@@ -774,9 +774,9 @@ describe("FlatRuleTester", () => {
         }, /Expected no autofixes to be suggested/u);
     });
 
-    it("should throw an error when the expected output is null and only some problems produce output", () => {
-        assert.throws(() => {
-            ruleTester.run("fixes-one-problem", require("../../fixtures/testers/rule-tester/fixes-one-problem"), {
+    it("should throw an error when the expected output is null and only some problems produce output", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("fixes-one-problem", require("../../fixtures/testers/rule-tester/fixes-one-problem"), {
                 valid: [],
                 invalid: [
                     { code: "foo", output: null, errors: 2 }
@@ -785,9 +785,9 @@ describe("FlatRuleTester", () => {
         }, /Expected no autofixes to be suggested/u);
     });
 
-    it("should throw an error when the expected output isn't specified and problems produce output", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the expected output isn't specified and problems produce output", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
                 ],
@@ -795,12 +795,12 @@ describe("FlatRuleTester", () => {
                     { code: "var foo = bar;", errors: 1 }
                 ]
             });
-        }, "The rule fixed the code. Please add 'output' property.");
+        }, /The rule fixed the code. Please add 'output' property./u);
     });
 
-    it("should throw an error if invalid code specifies wrong type", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should throw an error if invalid code specifies wrong type", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
                 ],
@@ -811,9 +811,9 @@ describe("FlatRuleTester", () => {
         }, /Error type should be CallExpression2, found CallExpression/u);
     });
 
-    it("should throw an error if invalid code specifies wrong line", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should throw an error if invalid code specifies wrong line", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
                 ],
@@ -824,9 +824,9 @@ describe("FlatRuleTester", () => {
         }, /Error line should be 5/u);
     });
 
-    it("should not skip line assertion if line is a falsy value", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should not skip line assertion if line is a falsy value", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
                 ],
@@ -837,12 +837,12 @@ describe("FlatRuleTester", () => {
         }, /Error line should be 0/u);
     });
 
-    it("should throw an error if invalid code specifies wrong column", () => {
+    it("should throw an error if invalid code specifies wrong column", async () => {
         const wrongColumn = 10,
             expectedErrorMessage = "Error column should be 1";
 
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: ["Eval(foo)"],
                 invalid: [{
                     code: "eval(foo)",
@@ -855,9 +855,9 @@ describe("FlatRuleTester", () => {
         }, expectedErrorMessage);
     });
 
-    it("should throw error for empty error array", () => {
-        assert.throws(() => {
-            ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+    it("should throw error for empty error array", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                 valid: [],
                 invalid: [{
                     code: "var foo;",
@@ -867,9 +867,9 @@ describe("FlatRuleTester", () => {
         }, /Invalid cases must have at least one error/u);
     });
 
-    it("should throw error for errors : 0", () => {
-        assert.throws(() => {
-            ruleTester.run(
+    it("should throw error for errors : 0", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run(
                 "suggestions-messageIds",
                 require("../../fixtures/testers/rule-tester/suggestions")
                     .withMessageIds,
@@ -886,9 +886,9 @@ describe("FlatRuleTester", () => {
         }, /Invalid cases must have 'error' value greater than 0/u);
     });
 
-    it("should not skip column assertion if column is a falsy value", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should not skip column assertion if column is a falsy value", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: ["Eval(foo)"],
                 invalid: [{
                     code: "var foo; eval(foo)",
@@ -898,9 +898,9 @@ describe("FlatRuleTester", () => {
         }, /Error column should be 0/u);
     });
 
-    it("should throw an error if invalid code specifies wrong endLine", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error if invalid code specifies wrong endLine", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
                 ],
@@ -908,12 +908,12 @@ describe("FlatRuleTester", () => {
                     { code: "var foo = bar;", output: "foo = bar", errors: [{ message: "Bad var.", type: "VariableDeclaration", endLine: 10 }] }
                 ]
             });
-        }, "Error endLine should be 10");
+        }, /Error endLine should be 10/u);
     });
 
-    it("should throw an error if invalid code specifies wrong endColumn", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error if invalid code specifies wrong endColumn", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
                 ],
@@ -921,12 +921,12 @@ describe("FlatRuleTester", () => {
                     { code: "var foo = bar;", output: "foo = bar", errors: [{ message: "Bad var.", type: "VariableDeclaration", endColumn: 10 }] }
                 ]
             });
-        }, "Error endColumn should be 10");
+        }, /Error endColumn should be 10/u);
     });
 
-    it("should throw an error if invalid code has the wrong number of errors", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should throw an error if invalid code has the wrong number of errors", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
                 ],
@@ -943,9 +943,9 @@ describe("FlatRuleTester", () => {
         }, /Should have 2 errors but had 1/u);
     });
 
-    it("should throw an error if invalid code does not have errors", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should throw an error if invalid code does not have errors", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
                 ],
@@ -956,9 +956,9 @@ describe("FlatRuleTester", () => {
         }, /Did not specify errors for an invalid test of no-eval/u);
     });
 
-    it("should throw an error if invalid code has the wrong explicit number of errors", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should throw an error if invalid code has the wrong explicit number of errors", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
                 ],
@@ -969,9 +969,9 @@ describe("FlatRuleTester", () => {
         }, /Should have 2 errors but had 1/u);
     });
 
-    it("should throw an error if there's a parsing error in a valid test", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should throw an error if there's a parsing error in a valid test", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "1eval('foo')"
                 ],
@@ -982,9 +982,9 @@ describe("FlatRuleTester", () => {
         }, /fatal parsing error/iu);
     });
 
-    it("should throw an error if there's a parsing error in an invalid test", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should throw an error if there's a parsing error in an invalid test", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "noeval('foo')"
                 ],
@@ -995,9 +995,9 @@ describe("FlatRuleTester", () => {
         }, /fatal parsing error/iu);
     });
 
-    it("should throw an error if there's a parsing error in an invalid test and errors is just a number", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should throw an error if there's a parsing error in an invalid test and errors is just a number", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "noeval('foo')"
                 ],
@@ -1009,9 +1009,9 @@ describe("FlatRuleTester", () => {
     });
 
     // https://github.com/eslint/eslint/issues/4779
-    it("should throw an error if there's a parsing error and output doesn't match", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should throw an error if there's a parsing error and output doesn't match", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [],
                 invalid: [
                     { code: "eval(`foo`", output: "eval(`foo`);", errors: [{}] }
@@ -1020,8 +1020,8 @@ describe("FlatRuleTester", () => {
         }, /fatal parsing error/iu);
     });
 
-    it("should not throw an error if invalid code has at least an expected empty error object", () => {
-        ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should not throw an error if invalid code has at least an expected empty error object", async () => {
+        await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
             valid: ["Eval(foo)"],
             invalid: [{
                 code: "eval(foo)",
@@ -1030,8 +1030,8 @@ describe("FlatRuleTester", () => {
         });
     });
 
-    it("should pass-through the globals config of valid tests to the to rule", () => {
-        ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
+    it("should pass-through the globals config of valid tests to the to rule", async () => {
+        await ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
             valid: [
                 {
                     code: "var test = 'foo'",
@@ -1050,8 +1050,8 @@ describe("FlatRuleTester", () => {
         });
     });
 
-    it("should pass-through the globals config of invalid tests to the rule", () => {
-        ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
+    it("should pass-through the globals config of invalid tests to the rule", async () => {
+        await ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
             valid: [
                 {
                     code: "var test = 'foo'",
@@ -1080,8 +1080,8 @@ describe("FlatRuleTester", () => {
         });
     });
 
-    it("should pass-through the settings config to rules", () => {
-        ruleTester.run("no-test-settings", require("../../fixtures/testers/rule-tester/no-test-settings"), {
+    it("should pass-through the settings config to rules", async () => {
+        await ruleTester.run("no-test-settings", require("../../fixtures/testers/rule-tester/no-test-settings"), {
             valid: [
                 {
                     code: "var test = 'bar'", settings: { test: 1 }
@@ -1096,8 +1096,8 @@ describe("FlatRuleTester", () => {
     });
 
     it("should pass-through the filename to the rule", () => {
-        (function() {
-            ruleTester.run("", require("../../fixtures/testers/rule-tester/no-test-filename"), {
+        (async function() {
+            await ruleTester.run("", require("../../fixtures/testers/rule-tester/no-test-filename"), {
                 valid: [
                     {
                         code: "var foo = 'bar'",
@@ -1116,8 +1116,8 @@ describe("FlatRuleTester", () => {
         }());
     });
 
-    it("should pass-through the options to the rule", () => {
-        ruleTester.run("no-invalid-args", require("../../fixtures/testers/rule-tester/no-invalid-args"), {
+    it("should pass-through the options to the rule", async () => {
+        await ruleTester.run("no-invalid-args", require("../../fixtures/testers/rule-tester/no-invalid-args"), {
             valid: [
                 {
                     code: "var foo = 'bar'",
@@ -1134,9 +1134,9 @@ describe("FlatRuleTester", () => {
         });
     });
 
-    it("should throw an error if the options are an object", () => {
-        assert.throws(() => {
-            ruleTester.run("no-invalid-args", require("../../fixtures/testers/rule-tester/no-invalid-args"), {
+    it("should throw an error if the options are an object", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-invalid-args", require("../../fixtures/testers/rule-tester/no-invalid-args"), {
                 valid: [
                     {
                         code: "foo",
@@ -1148,9 +1148,9 @@ describe("FlatRuleTester", () => {
         }, /options must be an array/u);
     });
 
-    it("should throw an error if the options are a number", () => {
-        assert.throws(() => {
-            ruleTester.run("no-invalid-args", require("../../fixtures/testers/rule-tester/no-invalid-args"), {
+    it("should throw an error if the options are a number", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-invalid-args", require("../../fixtures/testers/rule-tester/no-invalid-args"), {
                 valid: [
                     {
                         code: "foo",
@@ -1164,11 +1164,11 @@ describe("FlatRuleTester", () => {
 
     describe("Parsers", () => {
 
-        it("should pass-through the parser to the rule", () => {
+        it("should pass-through the parser to the rule", async () => {
             const spy = sinon.spy(ruleTester.linter, "verify");
             const esprima = require("esprima");
 
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     {
                         code: "Eval(foo)"
@@ -1194,7 +1194,7 @@ describe("FlatRuleTester", () => {
             );
         });
 
-        it("should pass-through services from parseForESLint to the rule", () => {
+        it("should pass-through services from parseForESLint to the rule", async () => {
             const enhancedParser = require("../../fixtures/parsers/enhanced-parser");
             const disallowHiRule = {
                 create: context => ({
@@ -1210,7 +1210,7 @@ describe("FlatRuleTester", () => {
                 })
             };
 
-            ruleTester.run("no-hi", disallowHiRule, {
+            await ruleTester.run("no-hi", disallowHiRule, {
                 valid: [
                     {
                         code: "'Hello!'",
@@ -1231,9 +1231,9 @@ describe("FlatRuleTester", () => {
             });
         });
 
-        it("should throw an error when the parser is not an object", () => {
-            assert.throws(() => {
-                ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+        it("should throw an error when the parser is not an object", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -1250,9 +1250,9 @@ describe("FlatRuleTester", () => {
     });
 
 
-    it("should prevent invalid options schemas", () => {
-        assert.throws(() => {
-            ruleTester.run("no-invalid-schema", require("../../fixtures/testers/rule-tester/no-invalid-schema"), {
+    it("should prevent invalid options schemas", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-invalid-schema", require("../../fixtures/testers/rule-tester/no-invalid-schema"), {
                 valid: [
                     "var answer = 6 * 7;",
                     { code: "var answer = 6 * 7;", options: [] }
@@ -1261,13 +1261,13 @@ describe("FlatRuleTester", () => {
                     { code: "var answer = 6 * 7;", options: ["bar"], errors: [{ message: "Expected nothing." }] }
                 ]
             });
-        }, "Schema for rule no-invalid-schema is invalid:,\titems: should be object\n\titems[0].enum: should NOT have fewer than 1 items\n\titems: should match some schema in anyOf");
+        }, /Schema for rule no-invalid-schema is invalid:,\titems: should be object\n\titems\[0\]\.enum: should NOT have fewer than 1 items\n\titems: should match some schema in anyOf/u);
 
     });
 
-    it("should prevent schema violations in options", () => {
-        assert.throws(() => {
-            ruleTester.run("no-schema-violation", require("../../fixtures/testers/rule-tester/no-schema-violation"), {
+    it("should prevent schema violations in options", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-schema-violation", require("../../fixtures/testers/rule-tester/no-schema-violation"), {
                 valid: [
                     "var answer = 6 * 7;",
                     { code: "var answer = 6 * 7;", options: ["foo"] }
@@ -1276,11 +1276,11 @@ describe("FlatRuleTester", () => {
                     { code: "var answer = 6 * 7;", options: ["bar"], errors: [{ message: "Expected foo." }] }
                 ]
             });
-        }, /Value "bar" should be equal to one of the allowed values./u);
+        }, /Value "bar" should be equal to one of the allowed values\./u);
 
     });
 
-    it("should disallow invalid defaults in rules", () => {
+    it("should disallow invalid defaults in rules", async () => {
         const ruleWithInvalidDefaults = {
             meta: {
                 schema: [
@@ -1304,8 +1304,8 @@ describe("FlatRuleTester", () => {
             create: () => ({})
         };
 
-        assert.throws(() => {
-            ruleTester.run("invalid-defaults", ruleWithInvalidDefaults, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("invalid-defaults", ruleWithInvalidDefaults, {
                 valid: [
                     {
                         code: "foo",
@@ -1317,20 +1317,20 @@ describe("FlatRuleTester", () => {
         }, /Schema for rule invalid-defaults is invalid: default is ignored for: data1\.foo/u);
     });
 
-    it("throw an error when an unknown config option is included", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("throw an error when an unknown config option is included", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     { code: "Eval(foo)", foo: "bar" }
                 ],
                 invalid: []
             });
-        }, /ESLint configuration in rule-tester is invalid./u);
+        }, /ESLint configuration in rule-tester is invalid: Unexpected key "foo" found\./u);
     });
 
-    it("throw an error when env is included in config", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("throw an error when env is included in config", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     { code: "Eval(foo)", env: ["es6"] }
                 ],
@@ -1339,14 +1339,14 @@ describe("FlatRuleTester", () => {
         }, /Key "env": This appears to be in eslintrc format rather than flat config format/u);
     });
 
-    it("should pass-through the tester config to the rule", () => {
+    it("should pass-through the tester config to the rule", async () => {
         ruleTester = new FlatRuleTester({
             languageOptions: {
                 globals: { test: true }
             }
         });
 
-        ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
+        await ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
             valid: [
                 "var test = 'foo'",
                 "var test2 = test"
@@ -1355,26 +1355,26 @@ describe("FlatRuleTester", () => {
         });
     });
 
-    it("should throw an error if AST was modified", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast"), {
+    it("should throw an error if AST was modified", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast"), {
                 valid: [
                     "var foo = 0;"
                 ],
                 invalid: []
             });
-        }, "Rule should not modify AST.");
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast"), {
+        }, /Rule should not modify AST\./u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast"), {
                 valid: [],
                 invalid: [
                     { code: "var bar = 0;", errors: ["error"] }
                 ]
             });
-        }, "Rule should not modify AST.");
+        }, /Rule should not modify AST\./u);
     });
 
-    it("should throw an error node.start is accessed with custom parser", () => {
+    it("should throw an error node.start is accessed with custom parser", async () => {
         const enhancedParser = require("../../fixtures/parsers/enhanced-parser");
 
         ruleTester = new FlatRuleTester({
@@ -1399,53 +1399,53 @@ describe("FlatRuleTester", () => {
             }
         };
 
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: ["foo(a, b)"],
                 invalid: []
             });
-        }, "Use node.range[0] instead of node.start");
+        }, /Use node\.range\[0\] instead of node\.start/u);
     });
 
-    it("should throw an error if AST was modified (at Program)", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-first"), {
+    it("should throw an error if AST was modified (at Program)", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-first"), {
                 valid: [
                     "var foo = 0;"
                 ],
                 invalid: []
             });
-        }, "Rule should not modify AST.");
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-first"), {
+        }, /Rule should not modify AST\./u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-first"), {
                 valid: [],
                 invalid: [
                     { code: "var bar = 0;", errors: ["error"] }
                 ]
             });
-        }, "Rule should not modify AST.");
+        }, /Rule should not modify AST\./u);
     });
 
-    it("should throw an error if AST was modified (at Program:exit)", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
+    it("should throw an error if AST was modified (at Program:exit)", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
                 valid: [
                     "var foo = 0;"
                 ],
                 invalid: []
             });
-        }, "Rule should not modify AST.");
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
+        }, /Rule should not modify AST\./u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
                 valid: [],
                 invalid: [
                     { code: "var bar = 0;", errors: ["error"] }
                 ]
             });
-        }, "Rule should not modify AST.");
+        }, /Rule should not modify AST\./u);
     });
 
-    it("should throw an error if rule uses start and end properties on nodes, tokens or comments", () => {
+    it("should throw an error if rule uses start and end properties on nodes, tokens or comments", async () => {
         const usesStartEndRule = {
             create(context) {
 
@@ -1477,194 +1477,194 @@ describe("FlatRuleTester", () => {
             }
         };
 
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: ["foo(a, b)"],
                 invalid: []
             });
-        }, "Use node.range[0] instead of node.start");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        }, /Use node\.range\[0\] instead of node\.start/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [],
                 invalid: [{ code: "var a = b * (c + d) / e;", errors: 1 }]
             });
-        }, "Use node.range[1] instead of node.end");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        }, /Use node\.range\[1\] instead of node\.end/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [],
                 invalid: [{ code: "var a = -b * c;", errors: 1 }]
             });
-        }, "Use token.range[0] instead of token.start");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        }, /Use token\.range\[0\] instead of token.start/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: ["var a = b ? c : d;"],
                 invalid: []
             });
-        }, "Use token.range[1] instead of token.end");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        }, /Use token\.range\[1\] instead of token\.end/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: ["function f() { /* comment */ }"],
                 invalid: []
             });
-        }, "Use token.range[0] instead of token.start");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        }, /Use token\.range\[0\] instead of token\.start/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [],
                 invalid: [{ code: "var x = //\n {\n //comment\n //\n}", errors: 1 }]
             });
-        }, "Use token.range[1] instead of token.end");
+        }, /Use token\.range\[1\] instead of token\.end/u);
 
         const enhancedParser = require("../../fixtures/parsers/enhanced-parser");
 
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [{ code: "foo(a, b)", languageOptions: { parser: enhancedParser } }],
                 invalid: []
             });
-        }, "Use node.range[0] instead of node.start");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        }, /Use node\.range\[0\] instead of node\.start/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [],
                 invalid: [{ code: "var a = b * (c + d) / e;", languageOptions: { parser: enhancedParser }, errors: 1 }]
             });
-        }, "Use node.range[1] instead of node.end");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        }, /Use node\.range\[1\] instead of node\.end/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [],
                 invalid: [{ code: "var a = -b * c;", languageOptions: { parser: enhancedParser }, errors: 1 }]
             });
-        }, "Use token.range[0] instead of token.start");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        }, /Use token\.range\[0\] instead of token\.start/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [{ code: "var a = b ? c : d;", languageOptions: { parser: enhancedParser } }],
                 invalid: []
             });
-        }, "Use token.range[1] instead of token.end");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        }, /Use token\.range\[1\] instead of token\.end/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [{ code: "function f() { /* comment */ }", languageOptions: { parser: enhancedParser } }],
                 invalid: []
             });
-        }, "Use token.range[0] instead of token.start");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        }, /Use token\.range\[0\] instead of token\.start/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [],
                 invalid: [{ code: "var x = //\n {\n //comment\n //\n}", languageOptions: { parser: enhancedParser }, errors: 1 }]
             });
-        }, "Use token.range[1] instead of token.end");
+        }, /Use token\.range\[1\] instead of token\.end/u);
 
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [{ code: "@foo class A {}", languageOptions: { parser: require("../../fixtures/parsers/enhanced-parser2") } }],
                 invalid: []
             });
-        }, "Use node.range[0] instead of node.start");
+        }, /Use node\.range\[0\] instead of node\.start/u);
     });
 
-    it("should throw an error if no test scenarios given", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"));
-        }, "Test Scenarios for rule foo : Could not find test scenario object");
+    it("should throw an error if no test scenarios given", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"));
+        }, /Test Scenarios for rule foo : Could not find test scenario object/u);
     });
 
-    it("should throw an error if no acceptable test scenario object is given", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), []);
-        }, "Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios\nCould not find any invalid test scenarios");
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), "");
-        }, "Test Scenarios for rule foo : Could not find test scenario object");
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), 2);
-        }, "Test Scenarios for rule foo : Could not find test scenario object");
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {});
-        }, "Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios\nCould not find any invalid test scenarios");
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
+    it("should throw an error if no acceptable test scenario object is given", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), []);
+        }, /Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios\nCould not find any invalid test scenarios/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), "");
+        }, /Test Scenarios for rule foo : Could not find test scenario object/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), 2);
+        }, /Test Scenarios for rule foo : Could not find test scenario object/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {});
+        }, /Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios\nCould not find any invalid test scenarios/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
                 valid: []
             });
-        }, "Test Scenarios for rule foo is invalid:\nCould not find any invalid test scenarios");
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
+        }, /Test Scenarios for rule foo is invalid:\nCould not find any invalid test scenarios/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
                 invalid: []
             });
-        }, "Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios");
+        }, /Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios/u);
     });
 
     // Nominal message/messageId use cases
-    it("should assert match if message provided in both test and result.", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
+    it("should assert match if message provided in both test and result.", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ message: "something" }] }]
             });
         }, /Avoid using variables named/u);
 
-        ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
+        await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
             valid: [],
             invalid: [{ code: "foo", errors: [{ message: "Avoid using variables named 'foo'." }] }]
         });
     });
 
-    it("should assert match between messageId if provided in both test and result.", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
+    it("should assert match between messageId if provided in both test and result.", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "unused" }] }]
             });
-        }, "messageId 'avoidFoo' does not match expected messageId 'unused'.");
+        }, /messageId 'avoidFoo' does not match expected messageId 'unused'\./u);
 
-        ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
+        await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
             valid: [],
             invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
         });
     });
-    it("should assert match between resulting message output if messageId and data provided in both test and result", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
+    it("should assert match between resulting message output if messageId and data provided in both test and result", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo", data: { name: "notFoo" } }] }]
             });
-        }, "Hydrated message \"Avoid using variables named 'notFoo'.\" does not match \"Avoid using variables named 'foo'.\"");
+        }, /Hydrated message "Avoid using variables named 'notFoo'\." does not match "Avoid using variables named 'foo'\./u);
     });
 
     // messageId/message misconfiguration cases
-    it("should throw if user tests for both message and messageId", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
+    it("should throw if user tests for both message and messageId", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ message: "something", messageId: "avoidFoo" }] }]
             });
-        }, "Error should not specify both 'message' and a 'messageId'.");
+        }, /Error should not specify both 'message' and a 'messageId'\./u);
     });
-    it("should throw if user tests for messageId but the rule doesn't use the messageId meta syntax.", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
+    it("should throw if user tests for messageId but the rule doesn't use the messageId meta syntax.", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
             });
-        }, "Error can not use 'messageId' if rule under test doesn't define 'meta.messages'");
+        }, /Error can not use 'messageId' if rule under test doesn't define 'meta.messages'/u);
     });
-    it("should throw if user tests for messageId not listed in the rule's meta syntax.", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
+    it("should throw if user tests for messageId not listed in the rule's meta syntax.", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "useFoo" }] }]
             });
         }, /Invalid messageId 'useFoo'/u);
     });
-    it("should throw if data provided without messageId.", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
+    it("should throw if data provided without messageId.", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ data: "something" }] }]
             });
-        }, "Error must specify 'messageId' if 'data' is used.");
+        }, /Error must specify 'messageId' if 'data' is used./u);
     });
 
     // fixable rules with or without `meta` property
-    it("should not throw an error if a rule that has `meta.fixable` produces fixes", () => {
+    it("should not throw an error if a rule that has `meta.fixable` produces fixes", async () => {
         const replaceProgramWith5Rule = {
             meta: {
                 fixable: "code"
@@ -1678,14 +1678,14 @@ describe("FlatRuleTester", () => {
             }
         };
 
-        ruleTester.run("replaceProgramWith5", replaceProgramWith5Rule, {
+        await ruleTester.run("replaceProgramWith5", replaceProgramWith5Rule, {
             valid: [],
             invalid: [
                 { code: "var foo = bar;", output: "5", errors: 1 }
             ]
         });
     });
-    it("should throw an error if a new-format rule that doesn't have `meta` produces fixes", () => {
+    it("should throw an error if a new-format rule that doesn't have `meta` produces fixes", async () => {
         const replaceProgramWith5Rule = {
             create(context) {
                 return {
@@ -1696,8 +1696,8 @@ describe("FlatRuleTester", () => {
             }
         };
 
-        assert.throws(() => {
-            ruleTester.run("replaceProgramWith5", replaceProgramWith5Rule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("replaceProgramWith5", replaceProgramWith5Rule, {
                 valid: [],
                 invalid: [
                     { code: "var foo = bar;", output: "5", errors: 1 }
@@ -1705,7 +1705,7 @@ describe("FlatRuleTester", () => {
             });
         }, /Fixable rules must set the `meta\.fixable` property/u);
     });
-    it("should throw an error if a legacy-format rule produces fixes", () => {
+    it("should throw an error if a legacy-format rule produces fixes", async () => {
 
         /**
          * Legacy-format rule (a function instead of an object with `create` method).
@@ -1720,8 +1720,8 @@ describe("FlatRuleTester", () => {
             };
         }
 
-        assert.throws(() => {
-            ruleTester.run("replaceProgramWith5", replaceProgramWith5Rule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("replaceProgramWith5", replaceProgramWith5Rule, {
                 valid: [],
                 invalid: [
                     { code: "var foo = bar;", output: "5", errors: 1 }
@@ -1731,8 +1731,8 @@ describe("FlatRuleTester", () => {
     });
 
     describe("suggestions", () => {
-        it("should pass with valid suggestions (tested using desc)", () => {
-            ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+        it("should pass with valid suggestions (tested using desc)", async () => {
+            await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
                 valid: [
                     "var boo;"
                 ],
@@ -1748,8 +1748,8 @@ describe("FlatRuleTester", () => {
             });
         });
 
-        it("should pass with suggestions on multiple lines", () => {
-            ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+        it("should pass with suggestions on multiple lines", async () => {
+            await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
                 valid: [],
                 invalid: [
                     {
@@ -1770,8 +1770,8 @@ describe("FlatRuleTester", () => {
             });
         });
 
-        it("should pass with valid suggestions (tested using messageIds)", () => {
-            ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should pass with valid suggestions (tested using messageIds)", async () => {
+            await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                 valid: [],
                 invalid: [{
                     code: "var foo;",
@@ -1788,8 +1788,8 @@ describe("FlatRuleTester", () => {
             });
         });
 
-        it("should pass with valid suggestions (one tested using messageIds, the other using desc)", () => {
-            ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should pass with valid suggestions (one tested using messageIds, the other using desc)", async () => {
+            await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                 valid: [],
                 invalid: [{
                     code: "var foo;",
@@ -1806,8 +1806,8 @@ describe("FlatRuleTester", () => {
             });
         });
 
-        it("should pass with valid suggestions (tested using both desc and messageIds for the same suggestion)", () => {
-            ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should pass with valid suggestions (tested using both desc and messageIds for the same suggestion)", async () => {
+            await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                 valid: [],
                 invalid: [{
                     code: "var foo;",
@@ -1826,8 +1826,8 @@ describe("FlatRuleTester", () => {
             });
         });
 
-        it("should pass with valid suggestions (tested using only desc on a rule that utilizes meta.messages)", () => {
-            ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should pass with valid suggestions (tested using only desc on a rule that utilizes meta.messages)", async () => {
+            await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                 valid: [],
                 invalid: [{
                     code: "var foo;",
@@ -1844,8 +1844,8 @@ describe("FlatRuleTester", () => {
             });
         });
 
-        it("should pass with valid suggestions (tested using messageIds and data)", () => {
-            ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should pass with valid suggestions (tested using messageIds and data)", async () => {
+            await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                 valid: [],
                 invalid: [{
                     code: "var foo;",
@@ -1865,8 +1865,8 @@ describe("FlatRuleTester", () => {
         });
 
 
-        it("should pass when tested using empty suggestion test objects if the array length is correct", () => {
-            ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should pass when tested using empty suggestion test objects if the array length is correct", async () => {
+            await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                 valid: [],
                 invalid: [{
                     code: "var foo;",
@@ -1877,9 +1877,9 @@ describe("FlatRuleTester", () => {
             });
         });
 
-        it("should support explicitly expecting no suggestions", () => {
-            [void 0, null, false, []].forEach(suggestions => {
-                ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/no-eval"), {
+        it("should support explicitly expecting no suggestions", async () => {
+            for (const suggestions of [void 0, null, false, []]) {
+                await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/no-eval"), {
                     valid: [],
                     invalid: [{
                         code: "eval('var foo');",
@@ -1888,13 +1888,14 @@ describe("FlatRuleTester", () => {
                         }]
                     }]
                 });
-            });
+            }
         });
 
-        it("should fail when expecting no suggestions and there are suggestions", () => {
-            [void 0, null, false, []].forEach(suggestions => {
-                assert.throws(() => {
-                    ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+        it("should fail when expecting no suggestions and there are suggestions", async () => {
+            for (const suggestions of [void 0, null, false, []]) {
+                // eslint-disable-next-line no-loop-func -- prototype code
+                await nodeAssert.rejects(async () => {
+                    await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
                         valid: [],
                         invalid: [{
                             code: "var foo;",
@@ -1903,13 +1904,13 @@ describe("FlatRuleTester", () => {
                             }]
                         }]
                     });
-                }, "Error should have no suggestions on error with message: \"Avoid using identifiers named 'foo'.\"");
-            });
+                }, /Error should have no suggestions on error with message: "Avoid using identifiers named 'foo'\./u);
+            }
         });
 
-        it("should fail when testing for suggestions that don't exist", () => {
-            assert.throws(() => {
-                ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+        it("should fail when testing for suggestions that don't exist", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -1920,12 +1921,12 @@ describe("FlatRuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error should have an array of suggestions. Instead received \"undefined\" on error with message: \"Bad var.\"");
+            }, /Error should have an array of suggestions. Instead received "undefined" on error with message: "Bad var./u);
         });
 
-        it("should fail when there are a different number of suggestions", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+        it("should fail when there are a different number of suggestions", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -1940,12 +1941,12 @@ describe("FlatRuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error should have 2 suggestions. Instead found 1 suggestions");
+            }, /Error should have 2 suggestions. Instead found 1 suggestions/u);
         });
 
-        it("should throw if the suggestion description doesn't match", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+        it("should throw if the suggestion description doesn't match", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -1957,12 +1958,12 @@ describe("FlatRuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 0 : desc should be \"not right\" but got \"Rename identifier 'foo' to 'bar'\" instead.");
+            }, /Error Suggestion at index 0 : desc should be "not right" but got "Rename identifier 'foo' to 'bar'" instead./u);
         });
 
-        it("should throw if the suggestion description doesn't match (although messageIds match)", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should throw if the suggestion description doesn't match (although messageIds match)", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -1979,12 +1980,12 @@ describe("FlatRuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 1 : desc should be \"Rename id 'foo' to 'baz'\" but got \"Rename identifier 'foo' to 'baz'\" instead.");
+            }, /Error Suggestion at index 1 : desc should be "Rename id 'foo' to 'baz'" but got "Rename identifier 'foo' to 'baz'" instead./u);
         });
 
-        it("should throw if the suggestion messageId doesn't match", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should throw if the suggestion messageId doesn't match", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -1999,12 +2000,12 @@ describe("FlatRuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 0 : messageId should be 'unused' but got 'renameFoo' instead.");
+            }, /Error Suggestion at index 0 : messageId should be 'unused' but got 'renameFoo' instead./u);
         });
 
-        it("should throw if the suggestion messageId doesn't match (although descriptions match)", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should throw if the suggestion messageId doesn't match (although descriptions match)", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2021,12 +2022,12 @@ describe("FlatRuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 1 : messageId should be 'avoidFoo' but got 'renameFoo' instead.");
+            }, /Error Suggestion at index 1 : messageId should be 'avoidFoo' but got 'renameFoo' instead./u);
         });
 
-        it("should throw if test specifies messageId for a rule that doesn't have meta.messages", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+        it("should throw if test specifies messageId for a rule that doesn't have meta.messages", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2038,12 +2039,12 @@ describe("FlatRuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 0 : Test can not use 'messageId' if rule under test doesn't define 'meta.messages'.");
+            }, /Error Suggestion at index 0 : Test can not use 'messageId' if rule under test doesn't define 'meta.messages'\./u);
         });
 
-        it("should throw if test specifies messageId that doesn't exist in the rule's meta.messages", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should throw if test specifies messageId that doesn't exist in the rule's meta.messages", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2058,12 +2059,12 @@ describe("FlatRuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 1 : Test has invalid messageId 'removeFoo', the rule under test allows only one of ['avoidFoo', 'unused', 'renameFoo'].");
+            }, /Error Suggestion at index 1 : Test has invalid messageId 'removeFoo', the rule under test allows only one of \['avoidFoo', 'unused', 'renameFoo'\]\./u);
         });
 
-        it("should throw if hydrated desc doesn't match (wrong data value)", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should throw if hydrated desc doesn't match (wrong data value)", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2080,12 +2081,12 @@ describe("FlatRuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 0 : Hydrated test desc \"Rename identifier 'foo' to 'car'\" does not match received desc \"Rename identifier 'foo' to 'bar'\".");
+            }, /Error Suggestion at index 0 : Hydrated test desc "Rename identifier 'foo' to 'car'" does not match received desc "Rename identifier 'foo' to 'bar'"./u);
         });
 
-        it("should throw if hydrated desc doesn't match (wrong data key)", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should throw if hydrated desc doesn't match (wrong data key)", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2102,12 +2103,13 @@ describe("FlatRuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 1 : Hydrated test desc \"Rename identifier 'foo' to '{{ newName }}'\" does not match received desc \"Rename identifier 'foo' to 'baz'\".");
+            // eslint-disable-next-line prefer-regex-literals, no-invalid-regexp -- prototype code
+            }, new RegExp("Error Suggestion at index 1 : Hydrated test desc \"Rename identifier 'foo' to '{{ newName }}'\" does not match received desc \"Rename identifier 'foo' to 'baz'\".", "u"));
         });
 
-        it("should throw if test specifies both desc and data", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should throw if test specifies both desc and data", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2125,12 +2127,12 @@ describe("FlatRuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 0 : Test should not specify both 'desc' and 'data'.");
+            }, /Error Suggestion at index 0 : Test should not specify both 'desc' and 'data'\./u);
         });
 
-        it("should throw if test uses data but doesn't specify messageId", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should throw if test uses data but doesn't specify messageId", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2146,12 +2148,12 @@ describe("FlatRuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 1 : Test must specify 'messageId' if 'data' is used.");
+            }, /Error Suggestion at index 1 : Test must specify 'messageId' if 'data' is used./u);
         });
 
-        it("should throw if the resulting suggestion output doesn't match", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+        it("should throw if the resulting suggestion output doesn't match", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2163,12 +2165,12 @@ describe("FlatRuleTester", () => {
                         }]
                     }]
                 });
-            }, "Expected the applied suggestion fix to match the test suggestion output");
+            }, /Expected the applied suggestion fix to match the test suggestion output/u);
         });
 
-        it("should fail when specified suggestion isn't an object", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+        it("should fail when specified suggestion isn't an object", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2177,10 +2179,10 @@ describe("FlatRuleTester", () => {
                         }]
                     }]
                 });
-            }, "Test suggestion in 'suggestions' array must be an object.");
+            }, /Test suggestion in 'suggestions' array must be an object./u);
 
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2195,12 +2197,12 @@ describe("FlatRuleTester", () => {
                         }]
                     }]
                 });
-            }, "Test suggestion in 'suggestions' array must be an object.");
+            }, /Test suggestion in 'suggestions' array must be an object./u);
         });
 
-        it("should fail when the suggestion is an object with an unknown property name", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+        it("should fail when the suggestion is an object with an unknown property name", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
                     valid: [
                         "var boo;"
                     ],
@@ -2216,9 +2218,9 @@ describe("FlatRuleTester", () => {
             }, /Invalid suggestion property name 'message'/u);
         });
 
-        it("should fail when any of the suggestions is an object with an unknown property name", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should fail when any of the suggestions is an object with an unknown property name", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2236,9 +2238,9 @@ describe("FlatRuleTester", () => {
             }, /Invalid suggestion property name 'outpt'/u);
         });
 
-        it("should throw an error if a rule that doesn't have `meta.hasSuggestions` enabled produces suggestions", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-missing-hasSuggestions-property", require("../../fixtures/testers/rule-tester/suggestions").withoutHasSuggestionsProperty, {
+        it("should throw an error if a rule that doesn't have `meta.hasSuggestions` enabled produces suggestions", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-missing-hasSuggestions-property", require("../../fixtures/testers/rule-tester/suggestions").withoutHasSuggestionsProperty, {
                     valid: [],
                     invalid: [
                         { code: "var foo = bar;", output: "5", errors: 1 }
@@ -2270,10 +2272,10 @@ describe("FlatRuleTester", () => {
 
     describe("naming test cases", () => {
 
-        it("should use the first argument as the name of the test suite", () => {
+        it("should use the first argument as the name of the test suite", async () => {
             const assertion = assertEmitted(ruleTesterTestEmitter, "describe", "this-is-a-rule-name");
 
-            ruleTester.run("this-is-a-rule-name", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("this-is-a-rule-name", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [],
                 invalid: []
             });
@@ -2281,10 +2283,10 @@ describe("FlatRuleTester", () => {
             return assertion;
         });
 
-        it("should use the test code as the name of the tests for valid code (string form)", () => {
+        it("should use the test code as the name of the tests for valid code (string form)", async () => {
             const assertion = assertEmitted(ruleTesterTestEmitter, "it", "valid(code);");
 
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "valid(code);"
                 ],
@@ -2294,10 +2296,10 @@ describe("FlatRuleTester", () => {
             return assertion;
         });
 
-        it("should use the test code as the name of the tests for valid code (object form)", () => {
+        it("should use the test code as the name of the tests for valid code (object form)", async () => {
             const assertion = assertEmitted(ruleTesterTestEmitter, "it", "valid(code);");
 
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     {
                         code: "valid(code);"
@@ -2309,10 +2311,10 @@ describe("FlatRuleTester", () => {
             return assertion;
         });
 
-        it("should use the test code as the name of the tests for invalid code", () => {
+        it("should use the test code as the name of the tests for invalid code", async () => {
             const assertion = assertEmitted(ruleTesterTestEmitter, "it", "var x = invalid(code);");
 
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [],
                 invalid: [
                     {
@@ -2327,10 +2329,10 @@ describe("FlatRuleTester", () => {
         });
 
         // https://github.com/eslint/eslint/issues/8142
-        it("should use the empty string as the name of the test if the test case is an empty string", () => {
+        it("should use the empty string as the name of the test if the test case is an empty string", async () => {
             const assertion = assertEmitted(ruleTesterTestEmitter, "it", "");
 
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     {
                         code: ""
@@ -2342,10 +2344,10 @@ describe("FlatRuleTester", () => {
             return assertion;
         });
 
-        it('should use the "name" property if set to a non-empty string', () => {
+        it('should use the "name" property if set to a non-empty string', async () => {
             const assertion = assertEmitted(ruleTesterTestEmitter, "it", "my test");
 
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [],
                 invalid: [
                     {
@@ -2360,10 +2362,10 @@ describe("FlatRuleTester", () => {
             return assertion;
         });
 
-        it('should use the "name" property if set to a non-empty string for valid cases too', () => {
+        it('should use the "name" property if set to a non-empty string for valid cases too', async () => {
             const assertion = assertEmitted(ruleTesterTestEmitter, "it", "my test");
 
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     {
                         name: "my test",
@@ -2377,10 +2379,10 @@ describe("FlatRuleTester", () => {
         });
 
 
-        it('should use the test code as the name if the "name" property is set to an empty string', () => {
+        it('should use the test code as the name if the "name" property is set to an empty string', async () => {
             const assertion = assertEmitted(ruleTesterTestEmitter, "it", "var x = invalid(code);");
 
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [],
                 invalid: [
                     {
@@ -2395,59 +2397,59 @@ describe("FlatRuleTester", () => {
             return assertion;
         });
 
-        it('should throw if "name" property is not a string', () => {
-            assert.throws(() => {
-                ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+        it('should throw if "name" property is not a string', async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                     valid: [{ code: "foo", name: 123 }],
                     invalid: [{ code: "foo" }]
 
                 });
             }, /Optional test case property 'name' must be a string/u);
 
-            assert.throws(() => {
-                ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                     valid: ["foo"],
                     invalid: [{ code: "foo", name: 123 }]
                 });
             }, /Optional test case property 'name' must be a string/u);
         });
 
-        it('should throw if "code" property is not a string', () => {
-            assert.throws(() => {
-                ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+        it('should throw if "code" property is not a string', async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                     valid: [{ code: 123 }],
                     invalid: [{ code: "foo" }]
 
                 });
             }, /Test case must specify a string value for 'code'/u);
 
-            assert.throws(() => {
-                ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                     valid: [123],
                     invalid: [{ code: "foo" }]
 
                 });
             }, /Test case must specify a string value for 'code'/u);
 
-            assert.throws(() => {
-                ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                     valid: ["foo"],
                     invalid: [{ code: 123 }]
                 });
             }, /Test case must specify a string value for 'code'/u);
         });
 
-        it('should throw if "code" property is missing', () => {
-            assert.throws(() => {
-                ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+        it('should throw if "code" property is missing', async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                     valid: [{ }],
                     invalid: [{ code: "foo" }]
 
                 });
             }, /Test case must specify a string value for 'code'/u);
 
-            assert.throws(() => {
-                ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                     valid: ["foo"],
                     invalid: [{ }]
                 });
@@ -2456,9 +2458,9 @@ describe("FlatRuleTester", () => {
     });
 
     // https://github.com/eslint/eslint/issues/11615
-    it("should fail the case if autofix made a syntax error.", () => {
-        assert.throw(() => {
-            ruleTester.run(
+    it("should fail the case if autofix made a syntax error.", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run(
                 "foo",
                 {
                     meta: {
@@ -2502,11 +2504,11 @@ describe("FlatRuleTester", () => {
             spyRuleTesterIt.resetHistory();
             ruleTester = new FlatRuleTester();
         });
-        it("should present newline when using back-tick as new line", () => {
+        it("should present newline when using back-tick as new line", async () => {
             const code = `
             var foo = bar;`;
 
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [],
                 invalid: [
                     {
@@ -2517,10 +2519,10 @@ describe("FlatRuleTester", () => {
             });
             sinon.assert.calledWith(spyRuleTesterIt, code);
         });
-        it("should present \\u0000 as a string", () => {
+        it("should present \\u0000 as a string", async () => {
             const code = "\u0000";
 
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [],
                 invalid: [
                     {
@@ -2531,10 +2533,10 @@ describe("FlatRuleTester", () => {
             });
             sinon.assert.calledWith(spyRuleTesterIt, "\\u0000");
         });
-        it("should present the pipe character correctly", () => {
+        it("should present the pipe character correctly", async () => {
             const code = "var foo = bar || baz;";
 
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [],
                 invalid: [
                     {
@@ -2559,18 +2561,18 @@ describe("FlatRuleTester", () => {
             })
         };
 
-        it("should throw if called from a valid test case", () => {
-            assert.throws(() => {
-                ruleTester.run("use-get-comments", useGetCommentsRule, {
+        it("should throw if called from a valid test case", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("use-get-comments", useGetCommentsRule, {
                     valid: [""],
                     invalid: []
                 });
             }, /`SourceCode#getComments\(\)` is deprecated/u);
         });
 
-        it("should throw if called from an invalid test case", () => {
-            assert.throws(() => {
-                ruleTester.run("use-get-comments", useGetCommentsRule, {
+        it("should throw if called from an invalid test case", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("use-get-comments", useGetCommentsRule, {
                     valid: [],
                     invalid: [{
                         code: "",

--- a/tests/lib/rule-tester/no-test-runners.js
+++ b/tests/lib/rule-tester/no-test-runners.js
@@ -13,20 +13,36 @@ const tmpDescribe = describe;
 it = null;
 describe = null;
 
-try {
-    const ruleTester = new RuleTester();
+// eslint-disable-next-line jsdoc/require-jsdoc -- prototype
+async function main() {
+    try {
+        const ruleTester = new RuleTester();
 
-    assert.throws(() => {
-        ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
-            valid: [
-                "bar = baz;"
-            ],
-            invalid: [
-                { code: "var foo = bar;", output: "invalid output", errors: 1 }
-            ]
-        });
-    }, new assert.AssertionError({ actual: " foo = bar;", expected: "invalid output", operator: "===" }).message);
-} finally {
-    it = tmpIt;
-    describe = tmpDescribe;
+        await assert.rejects(async () => {
+            await ruleTester.run(
+                "no-var",
+                require("../../fixtures/testers/rule-tester/no-var"),
+                {
+                    valid: ["bar = baz;"],
+                    invalid: [
+                        {
+                            code: "var foo = bar;",
+                            output: "invalid output",
+                            errors: 1
+                        }
+                    ]
+                }
+            );
+        }, new assert.AssertionError({ actual: " foo = bar;", expected: "invalid output", operator: "===" }).message);
+    } finally {
+        it = tmpIt;
+        describe = tmpDescribe;
+    }
 }
+
+main()
+    .catch(error => {
+        // eslint-disable-next-line no-console -- prototype
+        console.error(error);
+        process.exitCode = 1;
+    });

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -112,8 +112,8 @@ describe("RuleTester", () => {
                     ruleTester = new RuleTester();
                 });
 
-                it("is called by exclusive tests", () => {
-                    ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                it("is called by exclusive tests", async () => {
+                    await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                         valid: [{
                             code: "const notVar = 42;",
                             only: true
@@ -138,8 +138,8 @@ describe("RuleTester", () => {
                     ruleTester = new RuleTester();
                 });
 
-                it("is called by tests with `only` set", () => {
-                    ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                it("is called by tests with `only` set", async () => {
+                    await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                         valid: [{
                             code: "const notVar = 42;",
                             only: true
@@ -172,8 +172,8 @@ describe("RuleTester", () => {
                     ruleTester = new RuleTester();
                 });
 
-                it("is called by tests with `only` set", () => {
-                    ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                it("is called by tests with `only` set", async () => {
+                    await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                         valid: [{
                             code: "const notVar = 42;",
                             only: true
@@ -206,16 +206,16 @@ describe("RuleTester", () => {
                     ruleTester = new RuleTester();
                 });
 
-                it("throws an error recommending overriding `itOnly`", () => {
-                    assert.throws(() => {
-                        ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                it("throws an error recommending overriding `itOnly`", async () => {
+                    await nodeAssert.rejects(async () => {
+                        await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                             valid: [{
                                 code: "const notVar = 42;",
                                 only: true
                             }],
                             invalid: []
                         });
-                    }, "Set `RuleTester.itOnly` to use `only` with a custom test framework.");
+                    }, /Set `RuleTester.itOnly` to use `only` with a custom test framework./u);
                 });
             });
 
@@ -250,16 +250,16 @@ describe("RuleTester", () => {
                     ruleTester = new RuleTester();
                 });
 
-                it("throws an error explaining that the current test framework does not support `only`", () => {
-                    assert.throws(() => {
-                        ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                it("throws an error explaining that the current test framework does not support `only`", async () => {
+                    await nodeAssert.rejects(async () => {
+                        await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                             valid: [{
                                 code: "const notVar = 42;",
                                 only: true
                             }],
                             invalid: []
                         });
-                    }, "The current test framework does not support exclusive tests with `only`.");
+                    }, /The current test framework does not support exclusive tests with `only`\./u);
                 });
             });
         });
@@ -291,8 +291,8 @@ describe("RuleTester", () => {
                 ruleTester = new RuleTester();
             });
 
-            it("isn't called for normal tests", () => {
-                ruleTester.run(ruleName, rule, {
+            it("isn't called for normal tests", async () => {
+                await ruleTester.run(ruleName, rule, {
                     valid: ["const notVar = 42;"],
                     invalid: []
                 });
@@ -300,7 +300,7 @@ describe("RuleTester", () => {
                 sinon.assert.notCalled(spyRuleTesterItOnly);
             });
 
-            it("calls it or itOnly for every test case", () => {
+            it("calls it or itOnly for every test case", async () => {
 
                 /*
                  * `RuleTester` doesn't implement test case exclusivity itself.
@@ -309,7 +309,7 @@ describe("RuleTester", () => {
                  * instead of the regular `it()` function.
                  */
 
-                ruleTester.run(ruleName, rule, {
+                await ruleTester.run(ruleName, rule, {
                     valid: [
                         "const valid = 42;",
                         {
@@ -358,8 +358,8 @@ describe("RuleTester", () => {
         });
     });
 
-    it("should not throw an error when everything passes", () => {
-        ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should not throw an error when everything passes", async () => {
+        await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
             valid: [
                 "Eval(foo)"
             ],
@@ -369,10 +369,10 @@ describe("RuleTester", () => {
         });
     });
 
-    it("should throw an error when valid code is invalid", () => {
+    it("should throw an error when valid code is invalid", async () => {
 
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "eval(foo)"
                 ],
@@ -383,10 +383,10 @@ describe("RuleTester", () => {
         }, /Should have no errors but had 1/u);
     });
 
-    it("should throw an error when valid code is invalid", () => {
+    it("should throw an error when valid code is invalid", async () => {
 
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     { code: "eval(foo)" }
                 ],
@@ -397,10 +397,10 @@ describe("RuleTester", () => {
         }, /Should have no errors but had 1/u);
     });
 
-    it("should throw an error if invalid code is valid", () => {
+    it("should throw an error if invalid code is valid", async () => {
 
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
                 ],
@@ -411,9 +411,9 @@ describe("RuleTester", () => {
         }, /Should have 1 error but had 0/u);
     });
 
-    it("should throw an error when the error message is wrong", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the error message is wrong", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
 
                 // Only the invalid test matters here
                 valid: [
@@ -423,12 +423,12 @@ describe("RuleTester", () => {
                     { code: "var foo = bar;", errors: [{ message: "Bad error message." }] }
                 ]
             });
-        }, assertErrorMatches("Bad var.", "Bad error message."));
+        }, assertErrorMatches(/Bad var\./u, /Bad error message\./u));
     });
 
-    it("should throw an error when the error message regex does not match", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the error message regex does not match", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [],
                 invalid: [
                     { code: "var foo = bar;", errors: [{ message: /Bad error message/u }] }
@@ -437,9 +437,9 @@ describe("RuleTester", () => {
         }, /Expected 'Bad var.' to match \/Bad error message\//u);
     });
 
-    it("should throw an error when the error is not a supported type", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the error is not a supported type", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
 
                 // Only the invalid test matters here
                 valid: [
@@ -452,9 +452,9 @@ describe("RuleTester", () => {
         }, /Error should be a string, object, or RegExp/u);
     });
 
-    it("should throw an error when any of the errors is not a supported type", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when any of the errors is not a supported type", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
 
                 // Only the invalid test matters here
                 valid: [
@@ -467,9 +467,9 @@ describe("RuleTester", () => {
         }, /Error should be a string, object, or RegExp/u);
     });
 
-    it("should throw an error when the error is a string and it does not match error message", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the error is a string and it does not match error message", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
 
                 // Only the invalid test matters here
                 valid: [
@@ -479,12 +479,12 @@ describe("RuleTester", () => {
                     { code: "var foo = bar;", errors: ["Bad error message."] }
                 ]
             });
-        }, assertErrorMatches("Bad var.", "Bad error message."));
+        }, assertErrorMatches(/Bad var\./u, /Bad error message\./u));
     });
 
-    it("should throw an error when the error is a string and it does not match error message", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the error is a string and it does not match error message", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
 
                 valid: [
                 ],
@@ -495,8 +495,8 @@ describe("RuleTester", () => {
         }, /Expected 'Bad var.' to match \/Bad error message\//u);
     });
 
-    it("should not throw an error when the error is a string and it matches error message", () => {
-        ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should not throw an error when the error is a string and it matches error message", async () => {
+        await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
 
             // Only the invalid test matters here
             valid: [
@@ -508,8 +508,8 @@ describe("RuleTester", () => {
         });
     });
 
-    it("should not throw an error when the error is a regex and it matches error message", () => {
-        ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should not throw an error when the error is a regex and it matches error message", async () => {
+        await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
             valid: [],
             invalid: [
                 { code: "var foo = bar;", output: " foo = bar;", errors: [/^Bad var/u] }
@@ -517,9 +517,9 @@ describe("RuleTester", () => {
         });
     });
 
-    it("should throw an error when the error is an object with an unknown property name", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the error is an object with an unknown property name", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
                 ],
@@ -530,9 +530,9 @@ describe("RuleTester", () => {
         }, /Invalid error property name 'Message'/u);
     });
 
-    it("should throw an error when any of the errors is an object with an unknown property name", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when any of the errors is an object with an unknown property name", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
                 ],
@@ -549,8 +549,8 @@ describe("RuleTester", () => {
         }, /Invalid error property name 'typo'/u);
     });
 
-    it("should not throw an error when the error is a regex in an object and it matches error message", () => {
-        ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should not throw an error when the error is a regex in an object and it matches error message", async () => {
+        await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
             valid: [],
             invalid: [
                 { code: "var foo = bar;", output: " foo = bar;", errors: [{ message: /^Bad var/u }] }
@@ -558,9 +558,9 @@ describe("RuleTester", () => {
         });
     });
 
-    it("should throw an error when the expected output doesn't match", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the expected output doesn't match", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
                 ],
@@ -571,7 +571,7 @@ describe("RuleTester", () => {
         }, /Output is incorrect/u);
     });
 
-    it("should use strict equality to compare output", () => {
+    it("should use strict equality to compare output", async () => {
         const replaceProgramWith5Rule = {
             meta: {
                 fixable: "code"
@@ -585,15 +585,15 @@ describe("RuleTester", () => {
         };
 
         // Should not throw.
-        ruleTester.run("foo", replaceProgramWith5Rule, {
+        await ruleTester.run("foo", replaceProgramWith5Rule, {
             valid: [],
             invalid: [
                 { code: "var foo = bar;", output: "5", errors: 1 }
             ]
         });
 
-        assert.throws(() => {
-            ruleTester.run("foo", replaceProgramWith5Rule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", replaceProgramWith5Rule, {
                 valid: [],
                 invalid: [
                     { code: "var foo = bar;", output: 5, errors: 1 }
@@ -602,9 +602,9 @@ describe("RuleTester", () => {
         }, /Output is incorrect/u);
     });
 
-    it("should throw an error when the expected output doesn't match and errors is just a number", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the expected output doesn't match and errors is just a number", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
                 ],
@@ -615,8 +615,8 @@ describe("RuleTester", () => {
         }, /Output is incorrect/u);
     });
 
-    it("should not throw an error when the expected output is null and no errors produce output", () => {
-        ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should not throw an error when the expected output is null and no errors produce output", async () => {
+        await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
             valid: [
                 "bar = baz;"
             ],
@@ -627,9 +627,9 @@ describe("RuleTester", () => {
         });
     });
 
-    it("should throw an error when the expected output is null and problems produce output", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the expected output is null and problems produce output", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
                 ],
@@ -639,8 +639,8 @@ describe("RuleTester", () => {
             });
         }, /Expected no autofixes to be suggested/u);
 
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
                 ],
@@ -655,9 +655,9 @@ describe("RuleTester", () => {
         }, /Expected no autofixes to be suggested/u);
     });
 
-    it("should throw an error when the expected output is null and only some problems produce output", () => {
-        assert.throws(() => {
-            ruleTester.run("fixes-one-problem", require("../../fixtures/testers/rule-tester/fixes-one-problem"), {
+    it("should throw an error when the expected output is null and only some problems produce output", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("fixes-one-problem", require("../../fixtures/testers/rule-tester/fixes-one-problem"), {
                 valid: [],
                 invalid: [
                     { code: "foo", output: null, errors: 2 }
@@ -666,9 +666,9 @@ describe("RuleTester", () => {
         }, /Expected no autofixes to be suggested/u);
     });
 
-    it("should throw an error when the expected output isn't specified and problems produce output", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error when the expected output isn't specified and problems produce output", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
                 ],
@@ -676,12 +676,12 @@ describe("RuleTester", () => {
                     { code: "var foo = bar;", errors: 1 }
                 ]
             });
-        }, "The rule fixed the code. Please add 'output' property.");
+        }, /The rule fixed the code\. Please add 'output' property\./u);
     });
 
-    it("should throw an error if invalid code specifies wrong type", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should throw an error if invalid code specifies wrong type", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
                 ],
@@ -692,9 +692,9 @@ describe("RuleTester", () => {
         }, /Error type should be CallExpression2, found CallExpression/u);
     });
 
-    it("should throw an error if invalid code specifies wrong line", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should throw an error if invalid code specifies wrong line", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
                 ],
@@ -705,9 +705,9 @@ describe("RuleTester", () => {
         }, /Error line should be 5/u);
     });
 
-    it("should not skip line assertion if line is a falsy value", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should not skip line assertion if line is a falsy value", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
                 ],
@@ -718,12 +718,12 @@ describe("RuleTester", () => {
         }, /Error line should be 0/u);
     });
 
-    it("should throw an error if invalid code specifies wrong column", () => {
+    it("should throw an error if invalid code specifies wrong column", async () => {
         const wrongColumn = 10,
             expectedErrorMessage = "Error column should be 1";
 
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: ["Eval(foo)"],
                 invalid: [{
                     code: "eval(foo)",
@@ -736,9 +736,9 @@ describe("RuleTester", () => {
         }, expectedErrorMessage);
     });
 
-    it("should throw error for empty error array", () => {
-        assert.throws(() => {
-            ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+    it("should throw error for empty error array", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                 valid: [],
                 invalid: [{
                     code: "var foo;",
@@ -748,9 +748,9 @@ describe("RuleTester", () => {
         }, /Invalid cases must have at least one error/u);
     });
 
-    it("should throw error for errors : 0", () => {
-        assert.throws(() => {
-            ruleTester.run(
+    it("should throw error for errors : 0", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run(
                 "suggestions-messageIds",
                 require("../../fixtures/testers/rule-tester/suggestions")
                     .withMessageIds,
@@ -767,9 +767,9 @@ describe("RuleTester", () => {
         }, /Invalid cases must have 'error' value greater than 0/u);
     });
 
-    it("should not skip column assertion if column is a falsy value", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should not skip column assertion if column is a falsy value", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: ["Eval(foo)"],
                 invalid: [{
                     code: "var foo; eval(foo)",
@@ -779,9 +779,9 @@ describe("RuleTester", () => {
         }, /Error column should be 0/u);
     });
 
-    it("should throw an error if invalid code specifies wrong endLine", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error if invalid code specifies wrong endLine", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
                 ],
@@ -789,12 +789,12 @@ describe("RuleTester", () => {
                     { code: "var foo = bar;", output: "foo = bar", errors: [{ message: "Bad var.", type: "VariableDeclaration", endLine: 10 }] }
                 ]
             });
-        }, "Error endLine should be 10");
+        }, /Error endLine should be 10/u);
     });
 
-    it("should throw an error if invalid code specifies wrong endColumn", () => {
-        assert.throws(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+    it("should throw an error if invalid code specifies wrong endColumn", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
                 ],
@@ -802,12 +802,12 @@ describe("RuleTester", () => {
                     { code: "var foo = bar;", output: "foo = bar", errors: [{ message: "Bad var.", type: "VariableDeclaration", endColumn: 10 }] }
                 ]
             });
-        }, "Error endColumn should be 10");
+        }, /Error endColumn should be 10/u);
     });
 
-    it("should throw an error if invalid code has the wrong number of errors", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should throw an error if invalid code has the wrong number of errors", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
                 ],
@@ -824,9 +824,9 @@ describe("RuleTester", () => {
         }, /Should have 2 errors but had 1/u);
     });
 
-    it("should throw an error if invalid code does not have errors", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should throw an error if invalid code does not have errors", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
                 ],
@@ -837,9 +837,9 @@ describe("RuleTester", () => {
         }, /Did not specify errors for an invalid test of no-eval/u);
     });
 
-    it("should throw an error if invalid code has the wrong explicit number of errors", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should throw an error if invalid code has the wrong explicit number of errors", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
                 ],
@@ -850,9 +850,9 @@ describe("RuleTester", () => {
         }, /Should have 2 errors but had 1/u);
     });
 
-    it("should throw an error if there's a parsing error in a valid test", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should throw an error if there's a parsing error in a valid test", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "1eval('foo')"
                 ],
@@ -863,9 +863,9 @@ describe("RuleTester", () => {
         }, /fatal parsing error/iu);
     });
 
-    it("should throw an error if there's a parsing error in an invalid test", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should throw an error if there's a parsing error in an invalid test", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "noeval('foo')"
                 ],
@@ -876,9 +876,9 @@ describe("RuleTester", () => {
         }, /fatal parsing error/iu);
     });
 
-    it("should throw an error if there's a parsing error in an invalid test and errors is just a number", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should throw an error if there's a parsing error in an invalid test and errors is just a number", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "noeval('foo')"
                 ],
@@ -890,9 +890,9 @@ describe("RuleTester", () => {
     });
 
     // https://github.com/eslint/eslint/issues/4779
-    it("should throw an error if there's a parsing error and output doesn't match", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should throw an error if there's a parsing error and output doesn't match", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [],
                 invalid: [
                     { code: "eval(`foo`)", output: "eval(`foo`);", errors: [{}] }
@@ -901,8 +901,8 @@ describe("RuleTester", () => {
         }, /fatal parsing error/iu);
     });
 
-    it("should not throw an error if invalid code has at least an expected empty error object", () => {
-        ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("should not throw an error if invalid code has at least an expected empty error object", async () => {
+        await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
             valid: ["Eval(foo)"],
             invalid: [{
                 code: "eval(foo)",
@@ -911,8 +911,8 @@ describe("RuleTester", () => {
         });
     });
 
-    it("should pass-through the globals config of valid tests to the to rule", () => {
-        ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
+    it("should pass-through the globals config of valid tests to the to rule", async () => {
+        await ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
             valid: [
                 "var test = 'foo'",
                 {
@@ -924,8 +924,8 @@ describe("RuleTester", () => {
         });
     });
 
-    it("should pass-through the globals config of invalid tests to the to rule", () => {
-        ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
+    it("should pass-through the globals config of invalid tests to the to rule", async () => {
+        await ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
             valid: ["var test = 'foo'"],
             invalid: [
                 {
@@ -941,8 +941,8 @@ describe("RuleTester", () => {
         });
     });
 
-    it("should pass-through the settings config to rules", () => {
-        ruleTester.run("no-test-settings", require("../../fixtures/testers/rule-tester/no-test-settings"), {
+    it("should pass-through the settings config to rules", async () => {
+        await ruleTester.run("no-test-settings", require("../../fixtures/testers/rule-tester/no-test-settings"), {
             valid: [
                 {
                     code: "var test = 'bar'", settings: { test: 1 }
@@ -956,29 +956,27 @@ describe("RuleTester", () => {
         });
     });
 
-    it("should pass-through the filename to the rule", () => {
-        (function() {
-            ruleTester.run("", require("../../fixtures/testers/rule-tester/no-test-filename"), {
-                valid: [
-                    {
-                        code: "var foo = 'bar'",
-                        filename: "somefile.js"
-                    }
-                ],
-                invalid: [
-                    {
-                        code: "var foo = 'bar'",
-                        errors: [
-                            { message: "Filename test was not defined." }
-                        ]
-                    }
-                ]
-            });
-        }());
+    it("should pass-through the filename to the rule", async () => {
+        await ruleTester.run("", require("../../fixtures/testers/rule-tester/no-test-filename"), {
+            valid: [
+                {
+                    code: "var foo = 'bar'",
+                    filename: "somefile.js"
+                }
+            ],
+            invalid: [
+                {
+                    code: "var foo = 'bar'",
+                    errors: [
+                        { message: "Filename test was not defined." }
+                    ]
+                }
+            ]
+        });
     });
 
-    it("should pass-through the options to the rule", () => {
-        ruleTester.run("no-invalid-args", require("../../fixtures/testers/rule-tester/no-invalid-args"), {
+    it("should pass-through the options to the rule", async () => {
+        await ruleTester.run("no-invalid-args", require("../../fixtures/testers/rule-tester/no-invalid-args"), {
             valid: [
                 {
                     code: "var foo = 'bar'",
@@ -995,9 +993,9 @@ describe("RuleTester", () => {
         });
     });
 
-    it("should throw an error if the options are an object", () => {
-        assert.throws(() => {
-            ruleTester.run("no-invalid-args", require("../../fixtures/testers/rule-tester/no-invalid-args"), {
+    it("should throw an error if the options are an object", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-invalid-args", require("../../fixtures/testers/rule-tester/no-invalid-args"), {
                 valid: [
                     {
                         code: "foo",
@@ -1009,9 +1007,9 @@ describe("RuleTester", () => {
         }, /options must be an array/u);
     });
 
-    it("should throw an error if the options are a number", () => {
-        assert.throws(() => {
-            ruleTester.run("no-invalid-args", require("../../fixtures/testers/rule-tester/no-invalid-args"), {
+    it("should throw an error if the options are a number", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-invalid-args", require("../../fixtures/testers/rule-tester/no-invalid-args"), {
                 valid: [
                     {
                         code: "foo",
@@ -1023,10 +1021,10 @@ describe("RuleTester", () => {
         }, /options must be an array/u);
     });
 
-    it("should pass-through the parser to the rule", () => {
+    it("should pass-through the parser to the rule", async () => {
         const spy = sinon.spy(ruleTester.linter, "verify");
 
-        ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+        await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
             valid: [
                 {
                     code: "Eval(foo)"
@@ -1043,7 +1041,7 @@ describe("RuleTester", () => {
         assert.strictEqual(spy.args[1][1].parser, require.resolve("esprima"));
     });
 
-    it("should pass normalized ecmaVersion to the rule", () => {
+    it("should pass normalized ecmaVersion to the rule", async () => {
         const reportEcmaVersionRule = {
             meta: {
                 messages: {
@@ -1065,7 +1063,7 @@ describe("RuleTester", () => {
 
         const notEspree = require.resolve("../../fixtures/parsers/empty-program-parser");
 
-        ruleTester.run("report-ecma-version", reportEcmaVersionRule, {
+        await ruleTester.run("report-ecma-version", reportEcmaVersionRule, {
             valid: [],
             invalid: [
                 {
@@ -1243,7 +1241,7 @@ describe("RuleTester", () => {
         });
     });
 
-    it("should pass-through services from parseForESLint to the rule", () => {
+    it("should pass-through services from parseForESLint to the rule", async () => {
         const enhancedParserPath = require.resolve("../../fixtures/parsers/enhanced-parser");
         const disallowHiRule = {
             create: context => ({
@@ -1259,7 +1257,7 @@ describe("RuleTester", () => {
             })
         };
 
-        ruleTester.run("no-hi", disallowHiRule, {
+        await ruleTester.run("no-hi", disallowHiRule, {
             valid: [
                 {
                     code: "'Hello!'",
@@ -1276,9 +1274,9 @@ describe("RuleTester", () => {
         });
     });
 
-    it("should prevent invalid options schemas", () => {
-        assert.throws(() => {
-            ruleTester.run("no-invalid-schema", require("../../fixtures/testers/rule-tester/no-invalid-schema"), {
+    it("should prevent invalid options schemas", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-invalid-schema", require("../../fixtures/testers/rule-tester/no-invalid-schema"), {
                 valid: [
                     "var answer = 6 * 7;",
                     { code: "var answer = 6 * 7;", options: [] }
@@ -1287,13 +1285,13 @@ describe("RuleTester", () => {
                     { code: "var answer = 6 * 7;", options: ["bar"], errors: [{ message: "Expected nothing." }] }
                 ]
             });
-        }, "Schema for rule no-invalid-schema is invalid:,\titems: should be object\n\titems[0].enum: should NOT have fewer than 1 items\n\titems: should match some schema in anyOf");
+        }, /Schema for rule no-invalid-schema is invalid:,\titems: should be object\n\titems\[0\]\.enum: should NOT have fewer than 1 items\n\titems: should match some schema in anyOf/u);
 
     });
 
-    it("should prevent schema violations in options", () => {
-        assert.throws(() => {
-            ruleTester.run("no-schema-violation", require("../../fixtures/testers/rule-tester/no-schema-violation"), {
+    it("should prevent schema violations in options", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-schema-violation", require("../../fixtures/testers/rule-tester/no-schema-violation"), {
                 valid: [
                     "var answer = 6 * 7;",
                     { code: "var answer = 6 * 7;", options: ["foo"] }
@@ -1306,7 +1304,7 @@ describe("RuleTester", () => {
 
     });
 
-    it("should disallow invalid defaults in rules", () => {
+    it("should disallow invalid defaults in rules", async () => {
         const ruleWithInvalidDefaults = {
             meta: {
                 schema: [
@@ -1330,8 +1328,8 @@ describe("RuleTester", () => {
             create: () => ({})
         };
 
-        assert.throws(() => {
-            ruleTester.run("invalid-defaults", ruleWithInvalidDefaults, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("invalid-defaults", ruleWithInvalidDefaults, {
                 valid: [
                     {
                         code: "foo",
@@ -1343,9 +1341,9 @@ describe("RuleTester", () => {
         }, /Schema for rule invalid-defaults is invalid: default is ignored for: data1\.foo/u);
     });
 
-    it("throw an error when an unknown config option is included", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("throw an error when an unknown config option is included", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     { code: "Eval(foo)", foo: "bar" }
                 ],
@@ -1354,9 +1352,9 @@ describe("RuleTester", () => {
         }, /ESLint configuration in rule-tester is invalid./u);
     });
 
-    it("throw an error when an invalid config value is included", () => {
-        assert.throws(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+    it("throw an error when an invalid config value is included", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     { code: "Eval(foo)", env: ["es6"] }
                 ],
@@ -1365,12 +1363,12 @@ describe("RuleTester", () => {
         }, /Property "env" is the wrong type./u);
     });
 
-    it("should pass-through the tester config to the rule", () => {
+    it("should pass-through the tester config to the rule", async () => {
         ruleTester = new RuleTester({
             globals: { test: true }
         });
 
-        ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
+        await ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
             valid: [
                 "var test = 'foo'",
                 "var test2 = test"
@@ -1424,13 +1422,13 @@ describe("RuleTester", () => {
         assert.throw(setConfig(true), errorMessage);
     });
 
-    it("should pass-through the globals config to the tester then to the to rule", () => {
+    it("should pass-through the globals config to the tester then to the to rule", async () => {
         const config = { globals: { test: true } };
 
         RuleTester.setDefaultConfig(config);
         ruleTester = new RuleTester();
 
-        ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
+        await ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
             valid: [
                 "var test = 'foo'",
                 "var test2 = test"
@@ -1439,64 +1437,64 @@ describe("RuleTester", () => {
         });
     });
 
-    it("should throw an error if AST was modified", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast"), {
+    it("should throw an error if AST was modified", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast"), {
                 valid: [
                     "var foo = 0;"
                 ],
                 invalid: []
             });
-        }, "Rule should not modify AST.");
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast"), {
+        }, /Rule should not modify AST\./u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast"), {
                 valid: [],
                 invalid: [
                     { code: "var bar = 0;", errors: ["error"] }
                 ]
             });
-        }, "Rule should not modify AST.");
+        }, /Rule should not modify AST\./u);
     });
 
-    it("should throw an error if AST was modified (at Program)", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-first"), {
+    it("should throw an error if AST was modified (at Program)", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-first"), {
                 valid: [
                     "var foo = 0;"
                 ],
                 invalid: []
             });
-        }, "Rule should not modify AST.");
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-first"), {
+        }, /Rule should not modify AST\./u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-first"), {
                 valid: [],
                 invalid: [
                     { code: "var bar = 0;", errors: ["error"] }
                 ]
             });
-        }, "Rule should not modify AST.");
+        }, /Rule should not modify AST\./u);
     });
 
-    it("should throw an error if AST was modified (at Program:exit)", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
+    it("should throw an error if AST was modified (at Program:exit)", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
                 valid: [
                     "var foo = 0;"
                 ],
                 invalid: []
             });
-        }, "Rule should not modify AST.");
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
+        }, /Rule should not modify AST\./u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
                 valid: [],
                 invalid: [
                     { code: "var bar = 0;", errors: ["error"] }
                 ]
             });
-        }, "Rule should not modify AST.");
+        }, /Rule should not modify AST\./u);
     });
 
-    it("should throw an error if rule uses start and end properties on nodes, tokens or comments", () => {
+    it("should throw an error if rule uses start and end properties on nodes, tokens or comments", async () => {
         const usesStartEndRule = {
             create(context) {
 
@@ -1528,38 +1526,38 @@ describe("RuleTester", () => {
             }
         };
 
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: ["foo(a, b)"],
                 invalid: []
             });
         }, "Use node.range[0] instead of node.start");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [],
                 invalid: [{ code: "var a = b * (c + d) / e;", errors: 1 }]
             });
         }, "Use node.range[1] instead of node.end");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [],
                 invalid: [{ code: "var a = -b * c;", errors: 1 }]
             });
         }, "Use token.range[0] instead of token.start");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: ["var a = b ? c : d;"],
                 invalid: []
             });
         }, "Use token.range[1] instead of token.end");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: ["function f() { /* comment */ }"],
                 invalid: []
             });
         }, "Use token.range[0] instead of token.start");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [],
                 invalid: [{ code: "var x = //\n {\n //comment\n //\n}", errors: 1 }]
             });
@@ -1567,156 +1565,156 @@ describe("RuleTester", () => {
 
         const enhancedParserPath = require.resolve("../../fixtures/parsers/enhanced-parser");
 
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [{ code: "foo(a, b)", parser: enhancedParserPath }],
                 invalid: []
             });
         }, "Use node.range[0] instead of node.start");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [],
                 invalid: [{ code: "var a = b * (c + d) / e;", parser: enhancedParserPath, errors: 1 }]
             });
         }, "Use node.range[1] instead of node.end");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [],
                 invalid: [{ code: "var a = -b * c;", parser: enhancedParserPath, errors: 1 }]
             });
         }, "Use token.range[0] instead of token.start");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [{ code: "var a = b ? c : d;", parser: enhancedParserPath }],
                 invalid: []
             });
         }, "Use token.range[1] instead of token.end");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [{ code: "function f() { /* comment */ }", parser: enhancedParserPath }],
                 invalid: []
             });
         }, "Use token.range[0] instead of token.start");
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [],
                 invalid: [{ code: "var x = //\n {\n //comment\n //\n}", parser: enhancedParserPath, errors: 1 }]
             });
         }, "Use token.range[1] instead of token.end");
 
-        assert.throws(() => {
-            ruleTester.run("uses-start-end", usesStartEndRule, {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("uses-start-end", usesStartEndRule, {
                 valid: [{ code: "@foo class A {}", parser: require.resolve("../../fixtures/parsers/enhanced-parser2") }],
                 invalid: []
             });
         }, "Use node.range[0] instead of node.start");
     });
 
-    it("should throw an error if no test scenarios given", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"));
-        }, "Test Scenarios for rule foo : Could not find test scenario object");
+    it("should throw an error if no test scenarios given", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"));
+        }, /Test Scenarios for rule foo : Could not find test scenario object/u);
     });
 
-    it("should throw an error if no acceptable test scenario object is given", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), []);
-        }, "Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios\nCould not find any invalid test scenarios");
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), "");
-        }, "Test Scenarios for rule foo : Could not find test scenario object");
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), 2);
-        }, "Test Scenarios for rule foo : Could not find test scenario object");
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {});
-        }, "Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios\nCould not find any invalid test scenarios");
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
+    it("should throw an error if no acceptable test scenario object is given", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), []);
+        }, /Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios\nCould not find any invalid test scenarios/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), "");
+        }, /Test Scenarios for rule foo : Could not find test scenario object/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), 2);
+        }, /Test Scenarios for rule foo : Could not find test scenario object/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {});
+        }, /Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios\nCould not find any invalid test scenarios/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
                 valid: []
             });
-        }, "Test Scenarios for rule foo is invalid:\nCould not find any invalid test scenarios");
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
+        }, /Test Scenarios for rule foo is invalid:\nCould not find any invalid test scenarios/u);
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
                 invalid: []
             });
-        }, "Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios");
+        }, /Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios/u);
     });
 
     // Nominal message/messageId use cases
-    it("should assert match if message provided in both test and result.", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
+    it("should assert match if message provided in both test and result.", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ message: "something" }] }]
             });
         }, /Avoid using variables named/u);
 
-        ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
+        await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
             valid: [],
             invalid: [{ code: "foo", errors: [{ message: "Avoid using variables named 'foo'." }] }]
         });
     });
 
-    it("should assert match between messageId if provided in both test and result.", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
+    it("should assert match between messageId if provided in both test and result.", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "unused" }] }]
             });
-        }, "messageId 'avoidFoo' does not match expected messageId 'unused'.");
+        }, /messageId 'avoidFoo' does not match expected messageId 'unused'./u);
 
-        ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
+        await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
             valid: [],
             invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
         });
     });
-    it("should assert match between resulting message output if messageId and data provided in both test and result", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
+    it("should assert match between resulting message output if messageId and data provided in both test and result", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo", data: { name: "notFoo" } }] }]
             });
-        }, "Hydrated message \"Avoid using variables named 'notFoo'.\" does not match \"Avoid using variables named 'foo'.\"");
+        }, /Hydrated message "Avoid using variables named 'notFoo'." does not match "Avoid using variables named 'foo'."/u);
     });
 
     // messageId/message misconfiguration cases
-    it("should throw if user tests for both message and messageId", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
+    it("should throw if user tests for both message and messageId", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ message: "something", messageId: "avoidFoo" }] }]
             });
-        }, "Error should not specify both 'message' and a 'messageId'.");
+        }, /Error should not specify both 'message' and a 'messageId'./u);
     });
-    it("should throw if user tests for messageId but the rule doesn't use the messageId meta syntax.", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
+    it("should throw if user tests for messageId but the rule doesn't use the messageId meta syntax.", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
             });
-        }, "Error can not use 'messageId' if rule under test doesn't define 'meta.messages'");
+        }, /Error can not use 'messageId' if rule under test doesn't define 'meta.messages'/u);
     });
-    it("should throw if user tests for messageId not listed in the rule's meta syntax.", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
+    it("should throw if user tests for messageId not listed in the rule's meta syntax.", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "useFoo" }] }]
             });
         }, /Invalid messageId 'useFoo'/u);
     });
-    it("should throw if data provided without messageId.", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
+    it("should throw if data provided without messageId.", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ data: "something" }] }]
             });
-        }, "Error must specify 'messageId' if 'data' is used.");
+        }, /Error must specify 'messageId' if 'data' is used./u);
     });
 
     describe("suggestions", () => {
-        it("should pass with valid suggestions (tested using desc)", () => {
-            ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+        it("should pass with valid suggestions (tested using desc)", async () => {
+            await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
                 valid: [
                     "var boo;"
                 ],
@@ -1732,8 +1730,8 @@ describe("RuleTester", () => {
             });
         });
 
-        it("should pass with suggestions on multiple lines", () => {
-            ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+        it("should pass with suggestions on multiple lines", async () => {
+            await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
                 valid: [],
                 invalid: [
                     {
@@ -1754,8 +1752,8 @@ describe("RuleTester", () => {
             });
         });
 
-        it("should pass with valid suggestions (tested using messageIds)", () => {
-            ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should pass with valid suggestions (tested using messageIds)", async () => {
+            await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                 valid: [],
                 invalid: [{
                     code: "var foo;",
@@ -1772,8 +1770,8 @@ describe("RuleTester", () => {
             });
         });
 
-        it("should pass with valid suggestions (one tested using messageIds, the other using desc)", () => {
-            ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should pass with valid suggestions (one tested using messageIds, the other using desc)", async () => {
+            await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                 valid: [],
                 invalid: [{
                     code: "var foo;",
@@ -1790,8 +1788,8 @@ describe("RuleTester", () => {
             });
         });
 
-        it("should pass with valid suggestions (tested using both desc and messageIds for the same suggestion)", () => {
-            ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should pass with valid suggestions (tested using both desc and messageIds for the same suggestion)", async () => {
+            await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                 valid: [],
                 invalid: [{
                     code: "var foo;",
@@ -1810,8 +1808,8 @@ describe("RuleTester", () => {
             });
         });
 
-        it("should pass with valid suggestions (tested using only desc on a rule that utilizes meta.messages)", () => {
-            ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should pass with valid suggestions (tested using only desc on a rule that utilizes meta.messages)", async () => {
+            await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                 valid: [],
                 invalid: [{
                     code: "var foo;",
@@ -1828,8 +1826,8 @@ describe("RuleTester", () => {
             });
         });
 
-        it("should pass with valid suggestions (tested using messageIds and data)", () => {
-            ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should pass with valid suggestions (tested using messageIds and data)", async () => {
+            await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                 valid: [],
                 invalid: [{
                     code: "var foo;",
@@ -1849,8 +1847,8 @@ describe("RuleTester", () => {
         });
 
 
-        it("should pass when tested using empty suggestion test objects if the array length is correct", () => {
-            ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should pass when tested using empty suggestion test objects if the array length is correct", async () => {
+            await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                 valid: [],
                 invalid: [{
                     code: "var foo;",
@@ -1861,9 +1859,9 @@ describe("RuleTester", () => {
             });
         });
 
-        it("should support explicitly expecting no suggestions", () => {
-            [void 0, null, false, []].forEach(suggestions => {
-                ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/no-eval"), {
+        it("should support explicitly expecting no suggestions", async () => {
+            for (const suggestions of [void 0, null, false, []]) {
+                await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/no-eval"), {
                     valid: [],
                     invalid: [{
                         code: "eval('var foo');",
@@ -1872,13 +1870,14 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            });
+            }
         });
 
-        it("should fail when expecting no suggestions and there are suggestions", () => {
-            [void 0, null, false, []].forEach(suggestions => {
-                assert.throws(() => {
-                    ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+        it("should fail when expecting no suggestions and there are suggestions", async () => {
+            for (const suggestions of [void 0, null, false, []]) {
+                // eslint-disable-next-line no-loop-func -- prototype code
+                await nodeAssert.rejects(async () => {
+                    await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
                         valid: [],
                         invalid: [{
                             code: "var foo;",
@@ -1887,13 +1886,13 @@ describe("RuleTester", () => {
                             }]
                         }]
                     });
-                }, "Error should have no suggestions on error with message: \"Avoid using identifiers named 'foo'.\"");
-            });
+                }, /Error should have no suggestions on error with message: "Avoid using identifiers named 'foo'."/u);
+            }
         });
 
-        it("should fail when testing for suggestions that don't exist", () => {
-            assert.throws(() => {
-                ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+        it("should fail when testing for suggestions that don't exist", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -1904,12 +1903,12 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error should have an array of suggestions. Instead received \"undefined\" on error with message: \"Bad var.\"");
+            }, /Error should have an array of suggestions. Instead received "undefined" on error with message: "Bad var."/u);
         });
 
-        it("should fail when there are a different number of suggestions", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+        it("should fail when there are a different number of suggestions", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -1924,12 +1923,12 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error should have 2 suggestions. Instead found 1 suggestions");
+            }, /Error should have 2 suggestions. Instead found 1 suggestions/u);
         });
 
-        it("should throw if the suggestion description doesn't match", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+        it("should throw if the suggestion description doesn't match", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -1941,12 +1940,12 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 0 : desc should be \"not right\" but got \"Rename identifier 'foo' to 'bar'\" instead.");
+            }, /Error Suggestion at index 0 : desc should be "not right" but got "Rename identifier 'foo' to 'bar'" instead./u);
         });
 
-        it("should throw if the suggestion description doesn't match (although messageIds match)", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should throw if the suggestion description doesn't match (although messageIds match)", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -1963,12 +1962,12 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 1 : desc should be \"Rename id 'foo' to 'baz'\" but got \"Rename identifier 'foo' to 'baz'\" instead.");
+            }, /Error Suggestion at index 1 : desc should be "Rename id 'foo' to 'baz'" but got "Rename identifier 'foo' to 'baz'" instead./u);
         });
 
-        it("should throw if the suggestion messageId doesn't match", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should throw if the suggestion messageId doesn't match", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -1983,12 +1982,12 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 0 : messageId should be 'unused' but got 'renameFoo' instead.");
+            }, /Error Suggestion at index 0 : messageId should be 'unused' but got 'renameFoo' instead./u);
         });
 
-        it("should throw if the suggestion messageId doesn't match (although descriptions match)", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should throw if the suggestion messageId doesn't match (although descriptions match)", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2005,12 +2004,12 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 1 : messageId should be 'avoidFoo' but got 'renameFoo' instead.");
+            }, /Error Suggestion at index 1 : messageId should be 'avoidFoo' but got 'renameFoo' instead./u);
         });
 
-        it("should throw if test specifies messageId for a rule that doesn't have meta.messages", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+        it("should throw if test specifies messageId for a rule that doesn't have meta.messages", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2022,12 +2021,12 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 0 : Test can not use 'messageId' if rule under test doesn't define 'meta.messages'.");
+            }, /Error Suggestion at index 0 : Test can not use 'messageId' if rule under test doesn't define 'meta.messages'./u);
         });
 
-        it("should throw if test specifies messageId that doesn't exist in the rule's meta.messages", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should throw if test specifies messageId that doesn't exist in the rule's meta.messages", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2042,12 +2041,12 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 1 : Test has invalid messageId 'removeFoo', the rule under test allows only one of ['avoidFoo', 'unused', 'renameFoo'].");
+            }, /Error Suggestion at index 1 : Test has invalid messageId 'removeFoo', the rule under test allows only one of ['avoidFoo', 'unused', 'renameFoo']./u);
         });
 
-        it("should throw if hydrated desc doesn't match (wrong data value)", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should throw if hydrated desc doesn't match (wrong data value)", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2064,12 +2063,12 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 0 : Hydrated test desc \"Rename identifier 'foo' to 'car'\" does not match received desc \"Rename identifier 'foo' to 'bar'\".");
+            }, /Error Suggestion at index 0 : Hydrated test desc "Rename identifier 'foo' to 'car'" does not match received desc "Rename identifier 'foo' to 'bar'"./u);
         });
 
-        it("should throw if hydrated desc doesn't match (wrong data key)", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should throw if hydrated desc doesn't match (wrong data key)", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2086,12 +2085,13 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 1 : Hydrated test desc \"Rename identifier 'foo' to '{{ newName }}'\" does not match received desc \"Rename identifier 'foo' to 'baz'\".");
+            // eslint-disable-next-line prefer-regex-literals,, no-invalid-regexp -- prototype code
+            }, new RegExp("Error Suggestion at index 1 : Hydrated test desc \"Rename identifier 'foo' to '{{ newName }}'\" does not match received desc \"Rename identifier 'foo' to 'baz'\".", "u"));
         });
 
-        it("should throw if test specifies both desc and data", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should throw if test specifies both desc and data", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2109,12 +2109,12 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 0 : Test should not specify both 'desc' and 'data'.");
+            }, /Error Suggestion at index 0 : Test should not specify both 'desc' and 'data'./u);
         });
 
-        it("should throw if test uses data but doesn't specify messageId", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should throw if test uses data but doesn't specify messageId", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2130,12 +2130,12 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "Error Suggestion at index 1 : Test must specify 'messageId' if 'data' is used.");
+            }, /Error Suggestion at index 1 : Test must specify 'messageId' if 'data' is used./u);
         });
 
-        it("should throw if the resulting suggestion output doesn't match", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+        it("should throw if the resulting suggestion output doesn't match", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2147,12 +2147,12 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "Expected the applied suggestion fix to match the test suggestion output");
+            }, /Expected the applied suggestion fix to match the test suggestion output/u);
         });
 
-        it("should fail when specified suggestion isn't an object", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+        it("should fail when specified suggestion isn't an object", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2161,10 +2161,10 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "Test suggestion in 'suggestions' array must be an object.");
+            }, /Test suggestion in 'suggestions' array must be an object./u);
 
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2179,12 +2179,12 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "Test suggestion in 'suggestions' array must be an object.");
+            }, /Test suggestion in 'suggestions' array must be an object./u);
         });
 
-        it("should fail when the suggestion is an object with an unknown property name", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+        it("should fail when the suggestion is an object with an unknown property name", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
                     valid: [
                         "var boo;"
                     ],
@@ -2200,9 +2200,9 @@ describe("RuleTester", () => {
             }, /Invalid suggestion property name 'message'/u);
         });
 
-        it("should fail when any of the suggestions is an object with an unknown property name", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+        it("should fail when any of the suggestions is an object with an unknown property name", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
                     valid: [],
                     invalid: [{
                         code: "var foo;",
@@ -2220,15 +2220,15 @@ describe("RuleTester", () => {
             }, /Invalid suggestion property name 'outpt'/u);
         });
 
-        it("should throw an error if a rule that doesn't have `meta.hasSuggestions` enabled produces suggestions", () => {
-            assert.throws(() => {
-                ruleTester.run("suggestions-missing-hasSuggestions-property", require("../../fixtures/testers/rule-tester/suggestions").withoutHasSuggestionsProperty, {
+        it("should throw an error if a rule that doesn't have `meta.hasSuggestions` enabled produces suggestions", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("suggestions-missing-hasSuggestions-property", require("../../fixtures/testers/rule-tester/suggestions").withoutHasSuggestionsProperty, {
                     valid: [],
                     invalid: [
                         { code: "var foo = bar;", output: "5", errors: 1 }
                     ]
                 });
-            }, "Rules with suggestions must set the `meta.hasSuggestions` property to `true`.");
+            }, /Rules with suggestions must set the `meta.hasSuggestions` property to `true`./u);
         });
     });
 
@@ -2264,7 +2264,7 @@ describe("RuleTester", () => {
             processStub.restore();
         });
 
-        it("should log a deprecation warning when using the legacy function-style API for rule", () => {
+        it("should log a deprecation warning when using the legacy function-style API for rule", async () => {
 
             /**
              * Legacy-format rule (a function instead of an object with `create` method).
@@ -2279,7 +2279,7 @@ describe("RuleTester", () => {
                 };
             }
 
-            ruleTester.run("function-style-rule", functionStyleRule, {
+            await ruleTester.run("function-style-rule", functionStyleRule, {
                 valid: [],
                 invalid: [
                     { code: "var foo = bar;", errors: 1 }
@@ -2296,8 +2296,8 @@ describe("RuleTester", () => {
             );
         });
 
-        it("should log a deprecation warning when meta is not defined for the rule", () => {
-            ruleTester.run("rule-with-no-meta-1", ruleWithNoMeta, {
+        it("should log a deprecation warning when meta is not defined for the rule", async () => {
+            await ruleTester.run("rule-with-no-meta-1", ruleWithNoMeta, {
                 valid: [],
                 invalid: [
                     { code: "var foo = bar;", options: [{ foo: true }], errors: 1 }
@@ -2314,8 +2314,8 @@ describe("RuleTester", () => {
             );
         });
 
-        it("should log a deprecation warning when schema is not defined for the rule", () => {
-            ruleTester.run("rule-with-no-schema-1", ruleWithNoSchema, {
+        it("should log a deprecation warning when schema is not defined for the rule", async () => {
+            await ruleTester.run("rule-with-no-schema-1", ruleWithNoSchema, {
                 valid: [],
                 invalid: [
                     { code: "var foo = bar;", options: [{ foo: true }], errors: 1 }
@@ -2332,7 +2332,7 @@ describe("RuleTester", () => {
             );
         });
 
-        it("should log a deprecation warning when schema is `undefined`", () => {
+        it("should log a deprecation warning when schema is `undefined`", async () => {
             const ruleWithUndefinedSchema = {
                 meta: {
                     type: "problem",
@@ -2348,7 +2348,7 @@ describe("RuleTester", () => {
                 }
             };
 
-            ruleTester.run("rule-with-undefined-schema", ruleWithUndefinedSchema, {
+            await ruleTester.run("rule-with-undefined-schema", ruleWithUndefinedSchema, {
                 valid: [],
                 invalid: [
                     { code: "var foo = bar;", options: [{ foo: true }], errors: 1 }
@@ -2365,7 +2365,7 @@ describe("RuleTester", () => {
             );
         });
 
-        it("should log a deprecation warning when schema is `null`", () => {
+        it("should log a deprecation warning when schema is `null`", async () => {
             const ruleWithNullSchema = {
                 meta: {
                     type: "problem",
@@ -2380,7 +2380,7 @@ describe("RuleTester", () => {
                 }
             };
 
-            ruleTester.run("rule-with-null-schema", ruleWithNullSchema, {
+            await ruleTester.run("rule-with-null-schema", ruleWithNullSchema, {
                 valid: [],
                 invalid: [
                     { code: "var foo = bar;", options: [{ foo: true }], errors: 1 }
@@ -2397,7 +2397,7 @@ describe("RuleTester", () => {
             );
         });
 
-        it("should not log a deprecation warning when schema is an empty array", () => {
+        it("should not log a deprecation warning when schema is an empty array", async () => {
             const ruleWithEmptySchema = {
                 meta: {
                     type: "suggestion",
@@ -2412,7 +2412,7 @@ describe("RuleTester", () => {
                 }
             };
 
-            ruleTester.run("rule-with-no-options", ruleWithEmptySchema, {
+            await ruleTester.run("rule-with-no-options", ruleWithEmptySchema, {
                 valid: [],
                 invalid: [{ code: "var foo = bar;", errors: 1 }]
             });
@@ -2420,8 +2420,8 @@ describe("RuleTester", () => {
             assert.strictEqual(processStub.callCount, 0, "never calls `process.emitWarning()`");
         });
 
-        it("When the rule is an object-style rule, the legacy rule API warning is not emitted", () => {
-            ruleTester.run("rule-with-no-schema-2", ruleWithNoSchema, {
+        it("When the rule is an object-style rule, the legacy rule API warning is not emitted", async () => {
+            await ruleTester.run("rule-with-no-schema-2", ruleWithNoSchema, {
                 valid: [],
                 invalid: [
                     { code: "var foo = bar;", errors: 1 }
@@ -2431,7 +2431,7 @@ describe("RuleTester", () => {
             assert.strictEqual(processStub.callCount, 0, "never calls `process.emitWarning()`");
         });
 
-        it("When the rule has meta.schema and there are test cases with options, the missing schema warning is not emitted", () => {
+        it("When the rule has meta.schema and there are test cases with options, the missing schema warning is not emitted", async () => {
             const ruleWithSchema = {
                 meta: {
                     type: "suggestion",
@@ -2448,7 +2448,7 @@ describe("RuleTester", () => {
                 }
             };
 
-            ruleTester.run("rule-with-schema", ruleWithSchema, {
+            await ruleTester.run("rule-with-schema", ruleWithSchema, {
                 valid: [],
                 invalid: [
                     { code: "var foo = bar;", options: [true], errors: 1 }
@@ -2458,8 +2458,8 @@ describe("RuleTester", () => {
             assert.strictEqual(processStub.callCount, 0, "never calls `process.emitWarning()`");
         });
 
-        it("When the rule does not have meta, but there are no test cases with options, the missing schema warning is not emitted", () => {
-            ruleTester.run("rule-with-no-meta-2", ruleWithNoMeta, {
+        it("When the rule does not have meta, but there are no test cases with options, the missing schema warning is not emitted", async () => {
+            await ruleTester.run("rule-with-no-meta-2", ruleWithNoMeta, {
                 valid: [],
                 invalid: [
                     { code: "var foo = bar;", errors: 1 }
@@ -2469,8 +2469,8 @@ describe("RuleTester", () => {
             assert.strictEqual(processStub.callCount, 0, "never calls `process.emitWarning()`");
         });
 
-        it("When the rule has meta without meta.schema, but there are no test cases with options, the missing schema warning is not emitted", () => {
-            ruleTester.run("rule-with-no-schema-3", ruleWithNoSchema, {
+        it("When the rule has meta without meta.schema, but there are no test cases with options, the missing schema warning is not emitted", async () => {
+            await ruleTester.run("rule-with-no-schema-3", ruleWithNoSchema, {
                 valid: [],
                 invalid: [
                     { code: "var foo = bar;", errors: 1 }
@@ -2479,8 +2479,8 @@ describe("RuleTester", () => {
 
             assert.strictEqual(processStub.callCount, 0, "never calls `process.emitWarning()`");
         });
-        it("When the rule has meta without meta.schema, and some test cases have options property but it's an empty array, the missing schema warning is not emitted", () => {
-            ruleTester.run("rule-with-no-schema-4", ruleWithNoSchema, {
+        it("When the rule has meta without meta.schema, and some test cases have options property but it's an empty array, the missing schema warning is not emitted", async () => {
+            await ruleTester.run("rule-with-no-schema-4", ruleWithNoSchema, {
                 valid: [],
                 invalid: [
                     { code: "var foo = bar;", options: [], errors: 1 }
@@ -2513,10 +2513,10 @@ describe("RuleTester", () => {
 
     describe("naming test cases", () => {
 
-        it("should use the first argument as the name of the test suite", () => {
+        it("should use the first argument as the name of the test suite", async () => {
             const assertion = assertEmitted(ruleTesterTestEmitter, "describe", "this-is-a-rule-name");
 
-            ruleTester.run("this-is-a-rule-name", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("this-is-a-rule-name", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [],
                 invalid: []
             });
@@ -2524,10 +2524,10 @@ describe("RuleTester", () => {
             return assertion;
         });
 
-        it("should use the test code as the name of the tests for valid code (string form)", () => {
+        it("should use the test code as the name of the tests for valid code (string form)", async () => {
             const assertion = assertEmitted(ruleTesterTestEmitter, "it", "valid(code);");
 
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "valid(code);"
                 ],
@@ -2537,10 +2537,10 @@ describe("RuleTester", () => {
             return assertion;
         });
 
-        it("should use the test code as the name of the tests for valid code (object form)", () => {
+        it("should use the test code as the name of the tests for valid code (object form)", async () => {
             const assertion = assertEmitted(ruleTesterTestEmitter, "it", "valid(code);");
 
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     {
                         code: "valid(code);"
@@ -2552,10 +2552,10 @@ describe("RuleTester", () => {
             return assertion;
         });
 
-        it("should use the test code as the name of the tests for invalid code", () => {
+        it("should use the test code as the name of the tests for invalid code", async () => {
             const assertion = assertEmitted(ruleTesterTestEmitter, "it", "var x = invalid(code);");
 
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [],
                 invalid: [
                     {
@@ -2570,10 +2570,10 @@ describe("RuleTester", () => {
         });
 
         // https://github.com/eslint/eslint/issues/8142
-        it("should use the empty string as the name of the test if the test case is an empty string", () => {
+        it("should use the empty string as the name of the test if the test case is an empty string", async () => {
             const assertion = assertEmitted(ruleTesterTestEmitter, "it", "");
 
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     {
                         code: ""
@@ -2585,10 +2585,10 @@ describe("RuleTester", () => {
             return assertion;
         });
 
-        it('should use the "name" property if set to a non-empty string', () => {
+        it('should use the "name" property if set to a non-empty string', async () => {
             const assertion = assertEmitted(ruleTesterTestEmitter, "it", "my test");
 
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [],
                 invalid: [
                     {
@@ -2603,10 +2603,10 @@ describe("RuleTester", () => {
             return assertion;
         });
 
-        it('should use the "name" property if set to a non-empty string for valid cases too', () => {
+        it('should use the "name" property if set to a non-empty string for valid cases too', async () => {
             const assertion = assertEmitted(ruleTesterTestEmitter, "it", "my test");
 
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     {
                         name: "my test",
@@ -2620,10 +2620,10 @@ describe("RuleTester", () => {
         });
 
 
-        it('should use the test code as the name if the "name" property is set to an empty string', () => {
+        it('should use the test code as the name if the "name" property is set to an empty string', async () => {
             const assertion = assertEmitted(ruleTesterTestEmitter, "it", "var x = invalid(code);");
 
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [],
                 invalid: [
                     {
@@ -2638,59 +2638,59 @@ describe("RuleTester", () => {
             return assertion;
         });
 
-        it('should throw if "name" property is not a string', () => {
-            assert.throws(() => {
-                ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+        it('should throw if "name" property is not a string', async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                     valid: [{ code: "foo", name: 123 }],
                     invalid: [{ code: "foo" }]
 
                 });
             }, /Optional test case property 'name' must be a string/u);
 
-            assert.throws(() => {
-                ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                     valid: ["foo"],
                     invalid: [{ code: "foo", name: 123 }]
                 });
             }, /Optional test case property 'name' must be a string/u);
         });
 
-        it('should throw if "code" property is not a string', () => {
-            assert.throws(() => {
-                ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+        it('should throw if "code" property is not a string', async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                     valid: [{ code: 123 }],
                     invalid: [{ code: "foo" }]
 
                 });
             }, /Test case must specify a string value for 'code'/u);
 
-            assert.throws(() => {
-                ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                     valid: [123],
                     invalid: [{ code: "foo" }]
 
                 });
             }, /Test case must specify a string value for 'code'/u);
 
-            assert.throws(() => {
-                ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                     valid: ["foo"],
                     invalid: [{ code: 123 }]
                 });
             }, /Test case must specify a string value for 'code'/u);
         });
 
-        it('should throw if "code" property is missing', () => {
-            assert.throws(() => {
-                ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+        it('should throw if "code" property is missing', async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                     valid: [{ }],
                     invalid: [{ code: "foo" }]
 
                 });
             }, /Test case must specify a string value for 'code'/u);
 
-            assert.throws(() => {
-                ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
                     valid: ["foo"],
                     invalid: [{ }]
                 });
@@ -2699,9 +2699,9 @@ describe("RuleTester", () => {
     });
 
     // https://github.com/eslint/eslint/issues/11615
-    it("should fail the case if autofix made a syntax error.", () => {
-        assert.throw(() => {
-            ruleTester.run(
+    it("should fail the case if autofix made a syntax error.", async () => {
+        await nodeAssert.rejects(async () => {
+            await ruleTester.run(
                 "foo",
                 {
                     meta: {
@@ -2745,11 +2745,11 @@ describe("RuleTester", () => {
             spyRuleTesterIt.resetHistory();
             ruleTester = new RuleTester();
         });
-        it("should present newline when using back-tick as new line", () => {
+        it("should present newline when using back-tick as new line", async () => {
             const code = `
             var foo = bar;`;
 
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [],
                 invalid: [
                     {
@@ -2760,10 +2760,10 @@ describe("RuleTester", () => {
             });
             sinon.assert.calledWith(spyRuleTesterIt, code);
         });
-        it("should present \\u0000 as a string", () => {
+        it("should present \\u0000 as a string", async () => {
             const code = "\u0000";
 
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [],
                 invalid: [
                     {
@@ -2774,10 +2774,10 @@ describe("RuleTester", () => {
             });
             sinon.assert.calledWith(spyRuleTesterIt, "\\u0000");
         });
-        it("should present the pipe character correctly", () => {
+        it("should present the pipe character correctly", async () => {
             const code = "var foo = bar || baz;";
 
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+            await ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [],
                 invalid: [
                     {
@@ -2802,18 +2802,18 @@ describe("RuleTester", () => {
             })
         };
 
-        it("should throw if called from a valid test case", () => {
-            assert.throws(() => {
-                ruleTester.run("use-get-comments", useGetCommentsRule, {
+        it("should throw if called from a valid test case", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("use-get-comments", useGetCommentsRule, {
                     valid: [""],
                     invalid: []
                 });
             }, /`SourceCode#getComments\(\)` is deprecated/u);
         });
 
-        it("should throw if called from an invalid test case", () => {
-            assert.throws(() => {
-                ruleTester.run("use-get-comments", useGetCommentsRule, {
+        it("should throw if called from an invalid test case", async () => {
+            await nodeAssert.rejects(async () => {
+                await ruleTester.run("use-get-comments", useGetCommentsRule, {
                     valid: [],
                     invalid: [{
                         code: "",

--- a/tests/lib/rules/utils/ast-utils.js
+++ b/tests/lib/rules/utils/ast-utils.js
@@ -60,7 +60,7 @@ describe("ast-utils", () => {
     });
 
     describe("isTokenOnSameLine", () => {
-        it("should return false if the tokens are not on the same line", () => {
+        it("should return false if the tokens are not on the same line", async () => {
             linter.defineRule("checker", {
                 create: mustCall(context => ({
                     BlockStatement: mustCall(node => {
@@ -69,10 +69,10 @@ describe("ast-utils", () => {
                 }))
             });
 
-            linter.verify("if(a)\n{}", { rules: { checker: "error" } });
+            await linter.verify("if(a)\n{}", { rules: { checker: "error" } });
         });
 
-        it("should return true if the tokens are on the same line", () => {
+        it("should return true if the tokens are on the same line", async () => {
 
             linter.defineRule("checker", {
                 create: mustCall(context => ({
@@ -82,7 +82,7 @@ describe("ast-utils", () => {
                 }))
             });
 
-            linter.verify("if(a){}", { rules: { checker: "error" } });
+            await linter.verify("if(a){}", { rules: { checker: "error" } });
         });
     });
 
@@ -119,7 +119,7 @@ describe("ast-utils", () => {
     describe("checkReference", () => {
 
         // catch
-        it("should return true if reference is assigned for catch", () => {
+        it("should return true if reference is assigned for catch", async () => {
             linter.defineRule("checker", {
                 create: mustCall(context => ({
                     CatchClause: mustCall(node => {
@@ -130,11 +130,11 @@ describe("ast-utils", () => {
                 }))
             });
 
-            linter.verify("try { } catch (e) { e = 10; }", { rules: { checker: "error" } });
+            await linter.verify("try { } catch (e) { e = 10; }", { rules: { checker: "error" } });
         });
 
         // const
-        it("should return true if reference is assigned for const", () => {
+        it("should return true if reference is assigned for const", async () => {
             linter.defineRule("checker", {
                 create: mustCall(context => ({
                     VariableDeclaration: mustCall(node => {
@@ -145,10 +145,10 @@ describe("ast-utils", () => {
                 }))
             });
 
-            linter.verify("const a = 1; a = 2;", { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
+            await linter.verify("const a = 1; a = 2;", { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
         });
 
-        it("should return false if reference is not assigned for const", () => {
+        it("should return false if reference is not assigned for const", async () => {
             linter.defineRule("checker", {
                 create: mustCall(context => ({
                     VariableDeclaration: mustCall(node => {
@@ -159,11 +159,11 @@ describe("ast-utils", () => {
                 }))
             });
 
-            linter.verify("const a = 1; c = 2;", { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
+            await linter.verify("const a = 1; c = 2;", { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
         });
 
         // class
-        it("should return true if reference is assigned for class", () => {
+        it("should return true if reference is assigned for class", async () => {
             linter.defineRule("checker", {
                 create: mustCall(context => ({
                     ClassDeclaration: mustCall(node => {
@@ -175,10 +175,10 @@ describe("ast-utils", () => {
                 }))
             });
 
-            linter.verify("class A { }\n A = 1;", { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
+            await linter.verify("class A { }\n A = 1;", { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
         });
 
-        it("should return false if reference is not assigned for class", () => {
+        it("should return false if reference is not assigned for class", async () => {
             linter.defineRule("checker", {
                 create: mustCall(context => ({
                     ClassDeclaration: mustCall(node => {
@@ -189,7 +189,7 @@ describe("ast-utils", () => {
                 }))
             });
 
-            linter.verify("class A { } foo(A);", { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
+            await linter.verify("class A { } foo(A);", { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
         });
     });
 
@@ -383,7 +383,7 @@ describe("ast-utils", () => {
          *      node is in a loop.
          * @returns {void}
          */
-        function assertNodeTypeInLoop(code, nodeType, expectedInLoop) {
+        async function assertNodeTypeInLoop(code, nodeType, expectedInLoop) {
             const results = [];
 
             linter.defineRule("checker", {
@@ -393,34 +393,34 @@ describe("ast-utils", () => {
                     })
                 }))
             });
-            linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
+            await linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
 
             assert.lengthOf(results, 1);
             assert.strictEqual(results[0], expectedInLoop);
         }
 
-        it("should return true for a loop itself", () => {
-            assertNodeTypeInLoop("while (a) {}", "WhileStatement", true);
+        it("should return true for a loop itself", async () => {
+            await assertNodeTypeInLoop("while (a) {}", "WhileStatement", true);
         });
 
-        it("should return true for a loop condition", () => {
-            assertNodeTypeInLoop("while (a) {}", "Identifier", true);
+        it("should return true for a loop condition", async () => {
+            await assertNodeTypeInLoop("while (a) {}", "Identifier", true);
         });
 
-        it("should return true for a loop assignee", () => {
-            assertNodeTypeInLoop("for (var a in b) {}", "VariableDeclaration", true);
+        it("should return true for a loop assignee", async () => {
+            await assertNodeTypeInLoop("for (var a in b) {}", "VariableDeclaration", true);
         });
 
-        it("should return true for a node within a loop body", () => {
-            assertNodeTypeInLoop("for (var a of b) { console.log('Hello'); }", "Literal", true);
+        it("should return true for a node within a loop body", async () => {
+            await assertNodeTypeInLoop("for (var a of b) { console.log('Hello'); }", "Literal", true);
         });
 
-        it("should return false for a node outside a loop body", () => {
-            assertNodeTypeInLoop("while (true) {} a(b);", "CallExpression", false);
+        it("should return false for a node outside a loop body", async () => {
+            await assertNodeTypeInLoop("while (true) {} a(b);", "CallExpression", false);
         });
 
-        it("should return false when the loop is not in the current function", () => {
-            assertNodeTypeInLoop("while (true) { funcs.push(() => { var a; }); }", "VariableDeclaration", false);
+        it("should return false when the loop is not in the current function", async () => {
+            await assertNodeTypeInLoop("while (true) { funcs.push(() => { var a; }); }", "VariableDeclaration", false);
         });
     });
 
@@ -912,7 +912,7 @@ describe("ast-utils", () => {
         };
 
         Object.keys(expectedResults).forEach(key => {
-            it(`should return "${expectedResults[key]}" for "${key}".`, () => {
+            it(`should return "${expectedResults[key]}" for "${key}".`, async () => {
                 linter.defineRule("checker", {
                     create: mustCall(() => ({
                         ":function": mustCall(node => {
@@ -924,7 +924,7 @@ describe("ast-utils", () => {
                     }))
                 });
 
-                linter.verify(key, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 13 } });
+                await linter.verify(key, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 13 } });
             });
         });
     });
@@ -992,7 +992,7 @@ describe("ast-utils", () => {
                 }
             };
 
-            it(`should return "${JSON.stringify(expectedLoc)}" for "${key}".`, () => {
+            it(`should return "${JSON.stringify(expectedLoc)}" for "${key}".`, async () => {
                 linter.defineRule("checker", {
                     create: mustCall(() => ({
                         ":function": mustCall(node => {
@@ -1004,7 +1004,7 @@ describe("ast-utils", () => {
                     }))
                 });
 
-                linter.verify(key, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 13 } }, "test.js", true);
+                await linter.verify(key, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 13 } }, "test.js", true);
             });
         });
     });
@@ -1810,7 +1810,7 @@ describe("ast-utils", () => {
             assert.strictEqual(astUtils.isTopLevelExpressionStatement(node), false);
         });
 
-        it("should return false if the node is not an ExpressionStatement", () => {
+        it("should return false if the node is not an ExpressionStatement", async () => {
             linter.defineRule("checker", {
                 create: mustCall(() => ({
                     ":expression": mustCall(node => {
@@ -1819,7 +1819,7 @@ describe("ast-utils", () => {
                 }))
             });
 
-            linter.verify("var foo = () => \"use strict\";", { rules: { checker: "error" }, parserOptions: { ecmaVersion: 2022 } });
+            await linter.verify("var foo = () => \"use strict\";", { rules: { checker: "error" }, parserOptions: { ecmaVersion: 2022 } });
         });
 
         const expectedResults = [
@@ -1836,7 +1836,7 @@ describe("ast-utils", () => {
         ];
 
         expectedResults.forEach(([code, nodeText, expectedRetVal]) => {
-            it(`should return ${expectedRetVal} for \`${nodeText}\` in \`${code}\``, () => {
+            it(`should return ${expectedRetVal} for \`${nodeText}\` in \`${code}\``, async () => {
                 linter.defineRule("checker", {
                     create: mustCall(context => {
                         const assertForNode = mustCall(
@@ -1853,7 +1853,7 @@ describe("ast-utils", () => {
                     })
                 });
 
-                linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 2022 } });
+                await linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 2022 } });
             });
         });
     });
@@ -1892,7 +1892,7 @@ describe("ast-utils", () => {
         ];
 
         expectedResults.forEach(({ code, nodeText = code, expectedRetVal }) => {
-            it(`should return ${expectedRetVal} for \`${nodeText}\` in \`${code}\``, () => {
+            it(`should return ${expectedRetVal} for \`${nodeText}\` in \`${code}\``, async () => {
                 linter.defineRule("checker", {
                     create: mustCall(({ sourceCode }) => {
                         const assertForNode = mustCall(
@@ -1916,7 +1916,7 @@ describe("ast-utils", () => {
                     })
                 });
 
-                linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 2022 } });
+                await linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 2022 } });
             });
         });
     });

--- a/tests/lib/source-code/source-code.js
+++ b/tests/lib/source-code/source-code.js
@@ -11,6 +11,7 @@
 const fs = require("fs"),
     path = require("path"),
     assert = require("chai").assert,
+    nodeAssert = require("assert"),
     espree = require("espree"),
     sinon = require("sinon"),
     { Linter } = require("../../../lib/linter"),
@@ -245,7 +246,7 @@ describe("SourceCode", () => {
             sinon.verifyAndRestore();
         });
 
-        it("should not take a JSDoc comment from a FunctionDeclaration parent node when the node is a FunctionExpression", () => {
+        it("should not take a JSDoc comment from a FunctionDeclaration parent node when the node is a FunctionExpression", async () => {
 
             const code = [
                 "/** Desc*/",
@@ -274,12 +275,12 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" } });
+            await linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
 
-        it("should not take a JSDoc comment from a VariableDeclaration parent node when the node is a FunctionExpression inside a NewExpression", () => {
+        it("should not take a JSDoc comment from a VariableDeclaration parent node when the node is a FunctionExpression inside a NewExpression", async () => {
 
             const code = [
                 "/** Desc*/",
@@ -308,12 +309,12 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" } });
+            await linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
 
-        it("should not take a JSDoc comment from a FunctionExpression parent node when the node is a FunctionExpression", () => {
+        it("should not take a JSDoc comment from a FunctionExpression parent node when the node is a FunctionExpression", async () => {
 
             const code = [
                 "/** Desc*/",
@@ -344,12 +345,12 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" } });
+            await linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledTwice, "Event handler should be called twice.");
 
         });
 
-        it("should get JSDoc comment for FunctionExpression in a CallExpression", () => {
+        it("should get JSDoc comment for FunctionExpression in a CallExpression", async () => {
             const code = [
                 "call(",
                 "  /** Documentation. */",
@@ -382,11 +383,11 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" } });
+            await linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should get JSDoc comment for node when the node is a FunctionDeclaration", () => {
+        it("should get JSDoc comment for node when the node is a FunctionDeclaration", async () => {
 
             const code = [
                 "/** Desc*/",
@@ -416,12 +417,12 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" } });
+            await linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
 
-        it("should get JSDoc comment for node when the node is a FunctionDeclaration but its parent is an export", () => {
+        it("should get JSDoc comment for node when the node is a FunctionDeclaration but its parent is an export", async () => {
 
             const code = [
                 "/** Desc*/",
@@ -451,13 +452,13 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6, sourceType: "module" } });
+            await linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6, sourceType: "module" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
 
 
-        it("should get JSDoc comment for node when the node is a FunctionDeclaration but not the first statement", () => {
+        it("should get JSDoc comment for node when the node is a FunctionDeclaration but not the first statement", async () => {
 
             const code = [
                 "'use strict';",
@@ -488,13 +489,13 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" } });
+            await linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
 
 
-        it("should not get JSDoc comment for node when the node is a FunctionDeclaration inside of an IIFE without a JSDoc comment", () => {
+        it("should not get JSDoc comment for node when the node is a FunctionDeclaration inside of an IIFE without a JSDoc comment", async () => {
 
             const code = [
                 "/** Desc*/",
@@ -525,12 +526,12 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" } });
+            await linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
 
-        it("should get JSDoc comment for node when the node is a FunctionDeclaration and there are multiple comments", () => {
+        it("should get JSDoc comment for node when the node is a FunctionDeclaration and there are multiple comments", async () => {
 
             const code = [
                 "/* Code is good */",
@@ -561,12 +562,12 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" } });
+            await linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
 
-        it("should get JSDoc comment for node when the node is a FunctionDeclaration inside of an IIFE", () => {
+        it("should get JSDoc comment for node when the node is a FunctionDeclaration inside of an IIFE", async () => {
 
             const code = [
                 "/** Code is good */",
@@ -599,11 +600,11 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" } });
+            await linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should get JSDoc comment for node when the node is a FunctionExpression inside of an object literal", () => {
+        it("should get JSDoc comment for node when the node is a FunctionExpression inside of an object literal", async () => {
 
             const code = [
                 "/** Code is good */",
@@ -636,11 +637,11 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" } });
+            await linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should get JSDoc comment for node when the node is a ArrowFunctionExpression inside of an object literal", () => {
+        it("should get JSDoc comment for node when the node is a ArrowFunctionExpression inside of an object literal", async () => {
 
             const code = [
                 "/** Code is good */",
@@ -673,11 +674,11 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
+            await linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should get JSDoc comment for node when the node is a FunctionExpression in an assignment", () => {
+        it("should get JSDoc comment for node when the node is a FunctionExpression in an assignment", async () => {
 
             const code = [
                 "/** Code is good */",
@@ -708,11 +709,11 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" } });
+            await linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should get JSDoc comment for node when the node is a FunctionExpression in an assignment inside an IIFE", () => {
+        it("should get JSDoc comment for node when the node is a FunctionExpression in an assignment inside an IIFE", async () => {
 
             const code = [
                 "/** Code is good */",
@@ -747,11 +748,11 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" } });
+            await linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledTwice, "Event handler should be called.");
         });
 
-        it("should not get JSDoc comment for node when the node is a FunctionExpression in an assignment inside an IIFE without a JSDoc comment", () => {
+        it("should not get JSDoc comment for node when the node is a FunctionExpression in an assignment inside an IIFE without a JSDoc comment", async () => {
 
             const code = [
                 "/** Code is good */",
@@ -785,11 +786,11 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" } });
+            await linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledTwice, "Event handler should be called.");
         });
 
-        it("should not get JSDoc comment for node when the node is a FunctionExpression inside of a CallExpression", () => {
+        it("should not get JSDoc comment for node when the node is a FunctionExpression inside of a CallExpression", async () => {
 
             const code = [
                 "/** Code is good */",
@@ -821,11 +822,11 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" } });
+            await linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should not get JSDoc comment for node when the node is a FunctionExpression in an assignment inside an IIFE without a JSDoc comment", () => {
+        it("should not get JSDoc comment for node when the node is a FunctionExpression in an assignment inside an IIFE without a JSDoc comment", async () => {
 
             const code = [
                 "/**",
@@ -865,11 +866,11 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" } });
+            await linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledTwice, "Event handler should be called.");
         });
 
-        it("should get JSDoc comment for node when the node is a ClassExpression", () => {
+        it("should get JSDoc comment for node when the node is a ClassExpression", async () => {
 
             const code = [
                 "/** Merges two objects together.*/",
@@ -900,11 +901,11 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
+            await linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should get JSDoc comment for node when the node is a ClassDeclaration", () => {
+        it("should get JSDoc comment for node when the node is a ClassDeclaration", async () => {
 
             const code = [
                 "/** Merges two objects together.*/",
@@ -935,11 +936,11 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
+            await linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should not get JSDoc comment for class method even if the class has jsdoc present", () => {
+        it("should not get JSDoc comment for class method even if the class has jsdoc present", async () => {
 
             const code = [
                 "/** Merges two objects together.*/",
@@ -970,11 +971,11 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
+            await linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should get JSDoc comment for function expression even if function has blank lines on top", () => {
+        it("should get JSDoc comment for function expression even if function has blank lines on top", async () => {
 
             const code = [
                 "/** Merges two objects together.*/",
@@ -1009,11 +1010,11 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
+            await linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should not get JSDoc comment for function declaration when the function has blank lines on top", () => {
+        it("should not get JSDoc comment for function declaration when the function has blank lines on top", async () => {
 
             const code = [
                 "/** Merges two objects together.*/",
@@ -1046,13 +1047,13 @@ describe("SourceCode", () => {
                     });
                 }
             });
-            linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
+            await linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
     });
 
-    describe("getComments()", () => {
+    describe("getComments()", async () => {
         const config = { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6, sourceType: "module" } };
         let unusedAssertionFuncs;
 
@@ -1095,7 +1096,7 @@ describe("SourceCode", () => {
             );
         });
 
-        it("should return comments around nodes", () => {
+        it("should return comments around nodes", async () => {
             const code = [
                 "// Leading comment for VariableDeclaration",
                 "var a = 42;",
@@ -1114,10 +1115,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return trailing comments inside a block", () => {
+        it("should return trailing comments inside a block", async () => {
             const code = [
                 "{",
                 "    a();",
@@ -1137,10 +1138,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return comments within a conditional", () => {
+        it("should return comments within a conditional", async () => {
             const code = [
                 "/* Leading comment for IfStatement */",
                 "if (/* Leading comment for Identifier */ a) {}"
@@ -1157,10 +1158,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should not return comments within a previous node", () => {
+        it("should not return comments within a previous node", async () => {
             const code = [
                 "function a() {",
                 "    var b = {",
@@ -1184,10 +1185,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return comments only for children of parent node", () => {
+        it("should return comments only for children of parent node", async () => {
             const code = [
                 "var foo = {",
                 "    bar: 'bar'",
@@ -1210,10 +1211,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return comments for an export default anonymous class", () => {
+        it("should return comments for an export default anonymous class", async () => {
             const code = [
                 "/**",
                 " * Leading comment for ExportDefaultDeclaration",
@@ -1242,10 +1243,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return leading comments", () => {
+        it("should return leading comments", async () => {
             const code = [
                 "// Leading comment for first VariableDeclaration",
                 "var a;",
@@ -1274,10 +1275,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return shebang comments", () => {
+        it("should return shebang comments", async () => {
             const code = [
                 "#!/usr/bin/env node", // Leading comment for following VariableDeclaration
                 "var a;",
@@ -1305,10 +1306,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should include shebang comment when program only contains shebang", () => {
+        it("should include shebang comment when program only contains shebang", async () => {
             const code = "#!/usr/bin/env node";
 
             linter.defineRule("checker", {
@@ -1319,10 +1320,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return mixture of line and block comments", () => {
+        it("should return mixture of line and block comments", async () => {
             const code = [
                 "// Leading comment for VariableDeclaration",
                 "var zzz /* Trailing comment for Identifier */ = 777;",
@@ -1341,10 +1342,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return comments surrounding a call expression", () => {
+        it("should return comments surrounding a call expression", async () => {
             const code = [
                 "function a() {",
                 "    /* Leading comment for ExpressionStatement */",
@@ -1366,10 +1367,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return comments surrounding a debugger statement", () => {
+        it("should return comments surrounding a debugger statement", async () => {
             const code = [
                 "function a() {",
                 "    /* Leading comment for DebuggerStatement */",
@@ -1390,10 +1391,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return comments surrounding a return statement", () => {
+        it("should return comments surrounding a return statement", async () => {
             const code = [
                 "function a() {",
                 "    /* Leading comment for ReturnStatement */",
@@ -1414,10 +1415,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return comments surrounding a throw statement", () => {
+        it("should return comments surrounding a throw statement", async () => {
             const code = [
                 "function a() {",
                 "    /* Leading comment for ThrowStatement */",
@@ -1438,10 +1439,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return comments surrounding a while loop", () => {
+        it("should return comments surrounding a while loop", async () => {
             const code = [
                 "function f() {",
                 "    /* Leading comment for WhileStatement */",
@@ -1466,10 +1467,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return switch case fallthrough comments in functions", () => {
+        it("should return switch case fallthrough comments in functions", async () => {
             const code = [
                 "function bar(foo) {",
                 "    switch(foo) {",
@@ -1508,10 +1509,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return switch case fallthrough comments", () => {
+        it("should return switch case fallthrough comments", async () => {
             const code = [
                 "switch(foo) {",
                 "    /* Leading comment for SwitchCase */",
@@ -1545,10 +1546,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return switch case no-default comments in functions", () => {
+        it("should return switch case no-default comments in functions", async () => {
             const code = [
                 "function bar(a) {",
                 "    switch (a) {",
@@ -1586,10 +1587,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return switch case no-default comments", () => {
+        it("should return switch case no-default comments", async () => {
             const code = [
                 "switch (a) {",
                 "    case 1:",
@@ -1611,10 +1612,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return switch case no-default comments in nested functions", () => {
+        it("should return switch case no-default comments in nested functions", async () => {
             const code = [
                 "module.exports = function(context) {",
                 "    function isConstant(node) {",
@@ -1649,10 +1650,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return leading comments if the code only contains comments", () => {
+        it("should return leading comments if the code only contains comments", async () => {
             const code = [
                 "//comment",
                 "/*another comment*/"
@@ -1666,10 +1667,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return trailing comments if a block statement only contains comments", () => {
+        it("should return trailing comments if a block statement only contains comments", async () => {
             const code = [
                 "{",
                 "    //comment",
@@ -1686,10 +1687,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return trailing comments if a class body only contains comments", () => {
+        it("should return trailing comments if a class body only contains comments", async () => {
             const code = [
                 "class Foo {",
                 "    //comment",
@@ -1707,10 +1708,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return trailing comments if an object only contains comments", () => {
+        it("should return trailing comments if an object only contains comments", async () => {
             const code = [
                 "({",
                 "    //comment",
@@ -1728,10 +1729,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return trailing comments if an array only contains comments", () => {
+        it("should return trailing comments if an array only contains comments", async () => {
             const code = [
                 "[",
                 "    //comment",
@@ -1749,10 +1750,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return trailing comments if a switch statement only contains comments", () => {
+        it("should return trailing comments if a switch statement only contains comments", async () => {
             const code = [
                 "switch (foo) {",
                 "    //comment",
@@ -1770,10 +1771,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return comments for multiple declarations with a single variable", () => {
+        it("should return comments for multiple declarations with a single variable", async () => {
             const code = [
                 "// Leading comment for VariableDeclaration",
                 "var a, // Leading comment for next VariableDeclarator",
@@ -1805,10 +1806,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return comments when comments exist between var keyword and VariableDeclarator", () => {
+        it("should return comments when comments exist between var keyword and VariableDeclarator", async () => {
             const code = [
                 "var // Leading comment for VariableDeclarator",
                 "    // Leading comment for VariableDeclarator",
@@ -1826,10 +1827,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return attached comments between tokens to the correct nodes for empty function declarations", () => {
+        it("should return attached comments between tokens to the correct nodes for empty function declarations", async () => {
             const code = "/* 1 */ function /* 2 */ foo(/* 3 */) /* 4 */ { /* 5 */ } /* 6 */";
 
             linter.defineRule("checker", {
@@ -1843,10 +1844,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return attached comments between tokens to the correct nodes for empty class declarations", () => {
+        it("should return attached comments between tokens to the correct nodes for empty class declarations", async () => {
             const code = "/* 1 */ class /* 2 */ Foo /* 3 */ extends /* 4 */ Bar /* 5 */ { /* 6 */ } /* 7 */";
             let idCount = 0;
 
@@ -1870,10 +1871,10 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
 
-        it("should return attached comments between tokens to the correct nodes for empty switch statements", () => {
+        it("should return attached comments between tokens to the correct nodes for empty switch statements", async () => {
             const code = "/* 1 */ switch /* 2 */ (/* 3 */ foo /* 4 */) /* 5 */ { /* 6 */ } /* 7 */";
 
             linter.defineRule("checker", {
@@ -1886,7 +1887,7 @@ describe("SourceCode", () => {
                 }
             });
 
-            assert.isEmpty(linter.verify(code, config));
+            assert.isEmpty(await linter.verify(code, config));
         });
     });
 
@@ -2875,25 +2876,25 @@ describe("SourceCode", () => {
             parserOptions: { ecmaVersion: 6 }
         };
 
-        it("should work when passed a SourceCode object without a config", () => {
+        it("should work when passed a SourceCode object without a config", async () => {
             const ast = espree.parse(TEST_CODE, DEFAULT_CONFIG);
 
             const sourceCode = new SourceCode(TEST_CODE, ast),
-                messages = linter.verify(sourceCode);
+                messages = await linter.verify(sourceCode);
 
             assert.strictEqual(messages.length, 0);
         });
 
-        it("should work when passed a SourceCode object containing ES6 syntax and config", () => {
+        it("should work when passed a SourceCode object containing ES6 syntax and config", async () => {
             const sourceCode = new SourceCode("let foo = bar;", AST),
-                messages = linter.verify(sourceCode, CONFIG);
+                messages = await linter.verify(sourceCode, CONFIG);
 
             assert.strictEqual(messages.length, 0);
         });
 
-        it("should report an error when using let and ecmaVersion is 6", () => {
+        it("should report an error when using let and ecmaVersion is 6", async () => {
             const sourceCode = new SourceCode("let foo = bar;", AST),
-                messages = linter.verify(sourceCode, {
+                messages = await linter.verify(sourceCode, {
                     parserOptions: { ecmaVersion: 6 },
                     rules: { "no-unused-vars": 2 }
                 });
@@ -3027,7 +3028,7 @@ describe("SourceCode", () => {
 
     describe("getScope()", () => {
 
-        it("should throw an error when argument is missing", () => {
+        it("should throw an error when argument is missing", async () => {
 
             linter.defineRule("get-scope", {
                 create: context => ({
@@ -3037,8 +3038,8 @@ describe("SourceCode", () => {
                 })
             });
 
-            assert.throws(() => {
-                linter.verify(
+            await nodeAssert.rejects(async () => {
+                await linter.verify(
                     "foo",
                     {
                         rules: { "get-scope": 2 }
@@ -3055,7 +3056,7 @@ describe("SourceCode", () => {
          * @param {number} [ecmaVersion=5] The ECMAScript version.
          * @returns {{node: ASTNode, scope: escope.Scope}} Gotten scope.
          */
-        function getScope(code, astSelector, ecmaVersion = 5) {
+        async function getScope(code, astSelector, ecmaVersion = 5) {
             let node, scope;
 
             linter.defineRule("get-scope", {
@@ -3066,7 +3067,7 @@ describe("SourceCode", () => {
                     }
                 })
             });
-            linter.verify(
+            await linter.verify(
                 code,
                 {
                     parserOptions: { ecmaVersion },
@@ -3077,44 +3078,44 @@ describe("SourceCode", () => {
             return { node, scope };
         }
 
-        it("should return 'function' scope on FunctionDeclaration (ES5)", () => {
-            const { node, scope } = getScope("function f() {}", "FunctionDeclaration");
+        it("should return 'function' scope on FunctionDeclaration (ES5)", async () => {
+            const { node, scope } = await getScope("function f() {}", "FunctionDeclaration");
 
             assert.strictEqual(scope.type, "function");
             assert.strictEqual(scope.block, node);
         });
 
-        it("should return 'function' scope on FunctionExpression (ES5)", () => {
-            const { node, scope } = getScope("!function f() {}", "FunctionExpression");
+        it("should return 'function' scope on FunctionExpression (ES5)", async () => {
+            const { node, scope } = await getScope("!function f() {}", "FunctionExpression");
 
             assert.strictEqual(scope.type, "function");
             assert.strictEqual(scope.block, node);
         });
 
-        it("should return 'function' scope on the body of FunctionDeclaration (ES5)", () => {
-            const { node, scope } = getScope("function f() {}", "BlockStatement");
+        it("should return 'function' scope on the body of FunctionDeclaration (ES5)", async () => {
+            const { node, scope } = await getScope("function f() {}", "BlockStatement");
 
             assert.strictEqual(scope.type, "function");
             assert.strictEqual(scope.block, node.parent);
         });
 
-        it("should return 'function' scope on the body of FunctionDeclaration (ES2015)", () => {
-            const { node, scope } = getScope("function f() {}", "BlockStatement", 2015);
+        it("should return 'function' scope on the body of FunctionDeclaration (ES2015)", async () => {
+            const { node, scope } = await getScope("function f() {}", "BlockStatement", 2015);
 
             assert.strictEqual(scope.type, "function");
             assert.strictEqual(scope.block, node.parent);
         });
 
-        it("should return 'function' scope on BlockStatement in functions (ES5)", () => {
-            const { node, scope } = getScope("function f() { { var b; } }", "BlockStatement > BlockStatement");
+        it("should return 'function' scope on BlockStatement in functions (ES5)", async () => {
+            const { node, scope } = await getScope("function f() { { var b; } }", "BlockStatement > BlockStatement");
 
             assert.strictEqual(scope.type, "function");
             assert.strictEqual(scope.block, node.parent.parent);
             assert.deepStrictEqual(scope.variables.map(v => v.name), ["arguments", "b"]);
         });
 
-        it("should return 'block' scope on BlockStatement in functions (ES2015)", () => {
-            const { node, scope } = getScope("function f() { { let a; var b; } }", "BlockStatement > BlockStatement", 2015);
+        it("should return 'block' scope on BlockStatement in functions (ES2015)", async () => {
+            const { node, scope } = await getScope("function f() { { let a; var b; } }", "BlockStatement > BlockStatement", 2015);
 
             assert.strictEqual(scope.type, "block");
             assert.strictEqual(scope.upper.type, "function");
@@ -3123,8 +3124,8 @@ describe("SourceCode", () => {
             assert.deepStrictEqual(scope.variableScope.variables.map(v => v.name), ["arguments", "b"]);
         });
 
-        it("should return 'block' scope on nested BlockStatement in functions (ES2015)", () => {
-            const { node, scope } = getScope("function f() { { let a; { let b; var c; } } }", "BlockStatement > BlockStatement > BlockStatement", 2015);
+        it("should return 'block' scope on nested BlockStatement in functions (ES2015)", async () => {
+            const { node, scope } = await getScope("function f() { { let a; { let b; var c; } } }", "BlockStatement > BlockStatement > BlockStatement", 2015);
 
             assert.strictEqual(scope.type, "block");
             assert.strictEqual(scope.upper.type, "block");
@@ -3135,96 +3136,96 @@ describe("SourceCode", () => {
             assert.deepStrictEqual(scope.variableScope.variables.map(v => v.name), ["arguments", "c"]);
         });
 
-        it("should return 'function' scope on SwitchStatement in functions (ES5)", () => {
-            const { node, scope } = getScope("function f() { switch (a) { case 0: var b; } }", "SwitchStatement");
+        it("should return 'function' scope on SwitchStatement in functions (ES5)", async () => {
+            const { node, scope } = await getScope("function f() { switch (a) { case 0: var b; } }", "SwitchStatement");
 
             assert.strictEqual(scope.type, "function");
             assert.strictEqual(scope.block, node.parent.parent);
             assert.deepStrictEqual(scope.variables.map(v => v.name), ["arguments", "b"]);
         });
 
-        it("should return 'switch' scope on SwitchStatement in functions (ES2015)", () => {
-            const { node, scope } = getScope("function f() { switch (a) { case 0: let b; } }", "SwitchStatement", 2015);
+        it("should return 'switch' scope on SwitchStatement in functions (ES2015)", async () => {
+            const { node, scope } = await getScope("function f() { switch (a) { case 0: let b; } }", "SwitchStatement", 2015);
 
             assert.strictEqual(scope.type, "switch");
             assert.strictEqual(scope.block, node);
             assert.deepStrictEqual(scope.variables.map(v => v.name), ["b"]);
         });
 
-        it("should return 'function' scope on SwitchCase in functions (ES5)", () => {
-            const { node, scope } = getScope("function f() { switch (a) { case 0: var b; } }", "SwitchCase");
+        it("should return 'function' scope on SwitchCase in functions (ES5)", async () => {
+            const { node, scope } = await getScope("function f() { switch (a) { case 0: var b; } }", "SwitchCase");
 
             assert.strictEqual(scope.type, "function");
             assert.strictEqual(scope.block, node.parent.parent.parent);
             assert.deepStrictEqual(scope.variables.map(v => v.name), ["arguments", "b"]);
         });
 
-        it("should return 'switch' scope on SwitchCase in functions (ES2015)", () => {
-            const { node, scope } = getScope("function f() { switch (a) { case 0: let b; } }", "SwitchCase", 2015);
+        it("should return 'switch' scope on SwitchCase in functions (ES2015)", async () => {
+            const { node, scope } = await getScope("function f() { switch (a) { case 0: let b; } }", "SwitchCase", 2015);
 
             assert.strictEqual(scope.type, "switch");
             assert.strictEqual(scope.block, node.parent);
             assert.deepStrictEqual(scope.variables.map(v => v.name), ["b"]);
         });
 
-        it("should return 'catch' scope on CatchClause in functions (ES5)", () => {
-            const { node, scope } = getScope("function f() { try {} catch (e) { var a; } }", "CatchClause");
+        it("should return 'catch' scope on CatchClause in functions (ES5)", async () => {
+            const { node, scope } = await getScope("function f() { try {} catch (e) { var a; } }", "CatchClause");
 
             assert.strictEqual(scope.type, "catch");
             assert.strictEqual(scope.block, node);
             assert.deepStrictEqual(scope.variables.map(v => v.name), ["e"]);
         });
 
-        it("should return 'catch' scope on CatchClause in functions (ES2015)", () => {
-            const { node, scope } = getScope("function f() { try {} catch (e) { let a; } }", "CatchClause", 2015);
+        it("should return 'catch' scope on CatchClause in functions (ES2015)", async () => {
+            const { node, scope } = await getScope("function f() { try {} catch (e) { let a; } }", "CatchClause", 2015);
 
             assert.strictEqual(scope.type, "catch");
             assert.strictEqual(scope.block, node);
             assert.deepStrictEqual(scope.variables.map(v => v.name), ["e"]);
         });
 
-        it("should return 'catch' scope on the block of CatchClause in functions (ES5)", () => {
-            const { node, scope } = getScope("function f() { try {} catch (e) { var a; } }", "CatchClause > BlockStatement");
+        it("should return 'catch' scope on the block of CatchClause in functions (ES5)", async () => {
+            const { node, scope } = await getScope("function f() { try {} catch (e) { var a; } }", "CatchClause > BlockStatement");
 
             assert.strictEqual(scope.type, "catch");
             assert.strictEqual(scope.block, node.parent);
             assert.deepStrictEqual(scope.variables.map(v => v.name), ["e"]);
         });
 
-        it("should return 'block' scope on the block of CatchClause in functions (ES2015)", () => {
-            const { node, scope } = getScope("function f() { try {} catch (e) { let a; } }", "CatchClause > BlockStatement", 2015);
+        it("should return 'block' scope on the block of CatchClause in functions (ES2015)", async () => {
+            const { node, scope } = await getScope("function f() { try {} catch (e) { let a; } }", "CatchClause > BlockStatement", 2015);
 
             assert.strictEqual(scope.type, "block");
             assert.strictEqual(scope.block, node);
             assert.deepStrictEqual(scope.variables.map(v => v.name), ["a"]);
         });
 
-        it("should return 'function' scope on ForStatement in functions (ES5)", () => {
-            const { node, scope } = getScope("function f() { for (var i = 0; i < 10; ++i) {} }", "ForStatement");
+        it("should return 'function' scope on ForStatement in functions (ES5)", async () => {
+            const { node, scope } = await getScope("function f() { for (var i = 0; i < 10; ++i) {} }", "ForStatement");
 
             assert.strictEqual(scope.type, "function");
             assert.strictEqual(scope.block, node.parent.parent);
             assert.deepStrictEqual(scope.variables.map(v => v.name), ["arguments", "i"]);
         });
 
-        it("should return 'for' scope on ForStatement in functions (ES2015)", () => {
-            const { node, scope } = getScope("function f() { for (let i = 0; i < 10; ++i) {} }", "ForStatement", 2015);
+        it("should return 'for' scope on ForStatement in functions (ES2015)", async () => {
+            const { node, scope } = await getScope("function f() { for (let i = 0; i < 10; ++i) {} }", "ForStatement", 2015);
 
             assert.strictEqual(scope.type, "for");
             assert.strictEqual(scope.block, node);
             assert.deepStrictEqual(scope.variables.map(v => v.name), ["i"]);
         });
 
-        it("should return 'function' scope on the block body of ForStatement in functions (ES5)", () => {
-            const { node, scope } = getScope("function f() { for (var i = 0; i < 10; ++i) {} }", "ForStatement > BlockStatement");
+        it("should return 'function' scope on the block body of ForStatement in functions (ES5)", async () => {
+            const { node, scope } = await getScope("function f() { for (var i = 0; i < 10; ++i) {} }", "ForStatement > BlockStatement");
 
             assert.strictEqual(scope.type, "function");
             assert.strictEqual(scope.block, node.parent.parent.parent);
             assert.deepStrictEqual(scope.variables.map(v => v.name), ["arguments", "i"]);
         });
 
-        it("should return 'block' scope on the block body of ForStatement in functions (ES2015)", () => {
-            const { node, scope } = getScope("function f() { for (let i = 0; i < 10; ++i) {} }", "ForStatement > BlockStatement", 2015);
+        it("should return 'block' scope on the block body of ForStatement in functions (ES2015)", async () => {
+            const { node, scope } = await getScope("function f() { for (let i = 0; i < 10; ++i) {} }", "ForStatement > BlockStatement", 2015);
 
             assert.strictEqual(scope.type, "block");
             assert.strictEqual(scope.upper.type, "for");
@@ -3233,32 +3234,32 @@ describe("SourceCode", () => {
             assert.deepStrictEqual(scope.upper.variables.map(v => v.name), ["i"]);
         });
 
-        it("should return 'function' scope on ForInStatement in functions (ES5)", () => {
-            const { node, scope } = getScope("function f() { for (var key in obj) {} }", "ForInStatement");
+        it("should return 'function' scope on ForInStatement in functions (ES5)", async () => {
+            const { node, scope } = await getScope("function f() { for (var key in obj) {} }", "ForInStatement");
 
             assert.strictEqual(scope.type, "function");
             assert.strictEqual(scope.block, node.parent.parent);
             assert.deepStrictEqual(scope.variables.map(v => v.name), ["arguments", "key"]);
         });
 
-        it("should return 'for' scope on ForInStatement in functions (ES2015)", () => {
-            const { node, scope } = getScope("function f() { for (let key in obj) {} }", "ForInStatement", 2015);
+        it("should return 'for' scope on ForInStatement in functions (ES2015)", async () => {
+            const { node, scope } = await getScope("function f() { for (let key in obj) {} }", "ForInStatement", 2015);
 
             assert.strictEqual(scope.type, "for");
             assert.strictEqual(scope.block, node);
             assert.deepStrictEqual(scope.variables.map(v => v.name), ["key"]);
         });
 
-        it("should return 'function' scope on the block body of ForInStatement in functions (ES5)", () => {
-            const { node, scope } = getScope("function f() { for (var key in obj) {} }", "ForInStatement > BlockStatement");
+        it("should return 'function' scope on the block body of ForInStatement in functions (ES5)", async () => {
+            const { node, scope } = await getScope("function f() { for (var key in obj) {} }", "ForInStatement > BlockStatement");
 
             assert.strictEqual(scope.type, "function");
             assert.strictEqual(scope.block, node.parent.parent.parent);
             assert.deepStrictEqual(scope.variables.map(v => v.name), ["arguments", "key"]);
         });
 
-        it("should return 'block' scope on the block body of ForInStatement in functions (ES2015)", () => {
-            const { node, scope } = getScope("function f() { for (let key in obj) {} }", "ForInStatement > BlockStatement", 2015);
+        it("should return 'block' scope on the block body of ForInStatement in functions (ES2015)", async () => {
+            const { node, scope } = await getScope("function f() { for (let key in obj) {} }", "ForInStatement > BlockStatement", 2015);
 
             assert.strictEqual(scope.type, "block");
             assert.strictEqual(scope.upper.type, "for");
@@ -3267,16 +3268,16 @@ describe("SourceCode", () => {
             assert.deepStrictEqual(scope.upper.variables.map(v => v.name), ["key"]);
         });
 
-        it("should return 'for' scope on ForOfStatement in functions (ES2015)", () => {
-            const { node, scope } = getScope("function f() { for (let x of xs) {} }", "ForOfStatement", 2015);
+        it("should return 'for' scope on ForOfStatement in functions (ES2015)", async () => {
+            const { node, scope } = await getScope("function f() { for (let x of xs) {} }", "ForOfStatement", 2015);
 
             assert.strictEqual(scope.type, "for");
             assert.strictEqual(scope.block, node);
             assert.deepStrictEqual(scope.variables.map(v => v.name), ["x"]);
         });
 
-        it("should return 'block' scope on the block body of ForOfStatement in functions (ES2015)", () => {
-            const { node, scope } = getScope("function f() { for (let x of xs) {} }", "ForOfStatement > BlockStatement", 2015);
+        it("should return 'block' scope on the block body of ForOfStatement in functions (ES2015)", async () => {
+            const { node, scope } = await getScope("function f() { for (let x of xs) {} }", "ForOfStatement > BlockStatement", 2015);
 
             assert.strictEqual(scope.type, "block");
             assert.strictEqual(scope.upper.type, "for");
@@ -3285,8 +3286,8 @@ describe("SourceCode", () => {
             assert.deepStrictEqual(scope.upper.variables.map(v => v.name), ["x"]);
         });
 
-        it("should shadow the same name variable by the iteration variable.", () => {
-            const { node, scope } = getScope("let x; for (let x of x) {}", "ForOfStatement", 2015);
+        it("should shadow the same name variable by the iteration variable.", async () => {
+            const { node, scope } = await getScope("let x; for (let x of x) {}", "ForOfStatement", 2015);
 
             assert.strictEqual(scope.type, "for");
             assert.strictEqual(scope.upper.type, "global");
@@ -3301,7 +3302,7 @@ describe("SourceCode", () => {
     describe("getAncestors()", () => {
         const code = TEST_CODE;
 
-        it("should retrieve all ancestors when used", () => {
+        it("should retrieve all ancestors when used", async () => {
 
             let spy;
 
@@ -3326,11 +3327,11 @@ describe("SourceCode", () => {
                 rules: { "test/checker": "error" }
             };
 
-            flatLinter.verify(code, config, filename, true);
+            await flatLinter.verify(code, config, filename, true);
             assert(spy && spy.calledOnce, "Spy was not called.");
         });
 
-        it("should retrieve empty ancestors for root node", () => {
+        it("should retrieve empty ancestors for root node", async () => {
             let spy;
 
             const config = {
@@ -3355,11 +3356,11 @@ describe("SourceCode", () => {
                 rules: { "test/checker": "error" }
             };
 
-            flatLinter.verify(code, config);
+            await flatLinter.verify(code, config);
             assert(spy && spy.calledOnce, "Spy was not called.");
         });
 
-        it("should throw an error when the argument is missing", () => {
+        it("should throw an error when the argument is missing", async () => {
             let spy;
 
             const config = {
@@ -3386,7 +3387,7 @@ describe("SourceCode", () => {
                 rules: { "test/checker": "error" }
             };
 
-            flatLinter.verify(code, config);
+            await flatLinter.verify(code, config);
             assert(spy && spy.calledOnce, "Spy was not called.");
         });
     });
@@ -3401,7 +3402,7 @@ describe("SourceCode", () => {
          * @param {Array<Array<string>>} expectedNamesList An array of expected variable names. The expected variable names is an array of string.
          * @returns {void}
          */
-        function verify(code, type, expectedNamesList) {
+        async function verify(code, type, expectedNamesList) {
             linter.defineRules({
                 test: {
                     create(context) {
@@ -3481,7 +3482,7 @@ describe("SourceCode", () => {
                     }
                 }
             });
-            linter.verify(code, {
+            await linter.verify(code, {
                 rules: { test: 2 },
                 parserOptions: {
                     ecmaVersion: 6,
@@ -3493,7 +3494,7 @@ describe("SourceCode", () => {
             assert.strictEqual(0, expectedNamesList.length);
         }
 
-        it("VariableDeclaration", () => {
+        it("VariableDeclaration", async () => {
             const code = "\n var {a, x: [b], y: {c = 0}} = foo;\n let {d, x: [e], y: {f = 0}} = foo;\n const {g, x: [h], y: {i = 0}} = foo, {j, k = function(z) { let l; }} = bar;\n ";
             const namesList = [
                 ["a", "b", "c"],
@@ -3502,10 +3503,10 @@ describe("SourceCode", () => {
                 ["l"]
             ];
 
-            verify(code, "VariableDeclaration", namesList);
+            await verify(code, "VariableDeclaration", namesList);
         });
 
-        it("VariableDeclaration (on for-in/of loop)", () => {
+        it("VariableDeclaration (on for-in/of loop)", async () => {
 
             // TDZ scope is created here, so tests to exclude those.
             const code = "\n for (var {a, x: [b], y: {c = 0}} in foo) {\n let g;\n }\n for (let {d, x: [e], y: {f = 0}} of foo) {\n let h;\n }\n ";
@@ -3516,10 +3517,10 @@ describe("SourceCode", () => {
                 ["h"]
             ];
 
-            verify(code, "VariableDeclaration", namesList);
+            await verify(code, "VariableDeclaration", namesList);
         });
 
-        it("VariableDeclarator", () => {
+        it("VariableDeclarator", async () => {
 
             // TDZ scope is created here, so tests to exclude those.
             const code = "\n var {a, x: [b], y: {c = 0}} = foo;\n let {d, x: [e], y: {f = 0}} = foo;\n const {g, x: [h], y: {i = 0}} = foo, {j, k = function(z) { let l; }} = bar;\n ";
@@ -3531,20 +3532,20 @@ describe("SourceCode", () => {
                 ["l"]
             ];
 
-            verify(code, "VariableDeclarator", namesList);
+            await verify(code, "VariableDeclarator", namesList);
         });
 
-        it("FunctionDeclaration", () => {
+        it("FunctionDeclaration", async () => {
             const code = "\n function foo({a, x: [b], y: {c = 0}}, [d, e]) {\n let z;\n }\n function bar({f, x: [g], y: {h = 0}}, [i, j = function(q) { let w; }]) {\n let z;\n }\n ";
             const namesList = [
                 ["foo", "a", "b", "c", "d", "e"],
                 ["bar", "f", "g", "h", "i", "j"]
             ];
 
-            verify(code, "FunctionDeclaration", namesList);
+            await verify(code, "FunctionDeclaration", namesList);
         });
 
-        it("FunctionExpression", () => {
+        it("FunctionExpression", async () => {
             const code = "\n (function foo({a, x: [b], y: {c = 0}}, [d, e]) {\n let z;\n });\n (function bar({f, x: [g], y: {h = 0}}, [i, j = function(q) { let w; }]) {\n let z;\n });\n ";
             const namesList = [
                 ["foo", "a", "b", "c", "d", "e"],
@@ -3552,50 +3553,50 @@ describe("SourceCode", () => {
                 ["q"]
             ];
 
-            verify(code, "FunctionExpression", namesList);
+            await verify(code, "FunctionExpression", namesList);
         });
 
-        it("ArrowFunctionExpression", () => {
+        it("ArrowFunctionExpression", async () => {
             const code = "\n (({a, x: [b], y: {c = 0}}, [d, e]) => {\n let z;\n });\n (({f, x: [g], y: {h = 0}}, [i, j]) => {\n let z;\n });\n ";
             const namesList = [
                 ["a", "b", "c", "d", "e"],
                 ["f", "g", "h", "i", "j"]
             ];
 
-            verify(code, "ArrowFunctionExpression", namesList);
+            await verify(code, "ArrowFunctionExpression", namesList);
         });
 
-        it("ClassDeclaration", () => {
+        it("ClassDeclaration", async () => {
             const code = "\n class A { foo(x) { let y; } }\n class B { foo(x) { let y; } }\n ";
             const namesList = [
                 ["A", "A"], // outer scope's and inner scope's.
                 ["B", "B"]
             ];
 
-            verify(code, "ClassDeclaration", namesList);
+            await verify(code, "ClassDeclaration", namesList);
         });
 
-        it("ClassExpression", () => {
+        it("ClassExpression", async () => {
             const code = "\n (class A { foo(x) { let y; } });\n (class B { foo(x) { let y; } });\n ";
             const namesList = [
                 ["A"],
                 ["B"]
             ];
 
-            verify(code, "ClassExpression", namesList);
+            await verify(code, "ClassExpression", namesList);
         });
 
-        it("CatchClause", () => {
+        it("CatchClause", async () => {
             const code = "\n try {} catch ({a, b}) {\n let x;\n try {} catch ({c, d}) {\n let y;\n }\n }\n ";
             const namesList = [
                 ["a", "b"],
                 ["c", "d"]
             ];
 
-            verify(code, "CatchClause", namesList);
+            await verify(code, "CatchClause", namesList);
         });
 
-        it("ImportDeclaration", () => {
+        it("ImportDeclaration", async () => {
             const code = "\n import \"aaa\";\n import * as a from \"bbb\";\n import b, {c, x as d} from \"ccc\";\n ";
             const namesList = [
                 [],
@@ -3603,41 +3604,41 @@ describe("SourceCode", () => {
                 ["b", "c", "d"]
             ];
 
-            verify(code, "ImportDeclaration", namesList);
+            await verify(code, "ImportDeclaration", namesList);
         });
 
-        it("ImportSpecifier", () => {
+        it("ImportSpecifier", async () => {
             const code = "\n import \"aaa\";\n import * as a from \"bbb\";\n import b, {c, x as d} from \"ccc\";\n ";
             const namesList = [
                 ["c"],
                 ["d"]
             ];
 
-            verify(code, "ImportSpecifier", namesList);
+            await verify(code, "ImportSpecifier", namesList);
         });
 
-        it("ImportDefaultSpecifier", () => {
+        it("ImportDefaultSpecifier", async () => {
             const code = "\n import \"aaa\";\n import * as a from \"bbb\";\n import b, {c, x as d} from \"ccc\";\n ";
             const namesList = [
                 ["b"]
             ];
 
-            verify(code, "ImportDefaultSpecifier", namesList);
+            await verify(code, "ImportDefaultSpecifier", namesList);
         });
 
-        it("ImportNamespaceSpecifier", () => {
+        it("ImportNamespaceSpecifier", async () => {
             const code = "\n import \"aaa\";\n import * as a from \"bbb\";\n import b, {c, x as d} from \"ccc\";\n ";
             const namesList = [
                 ["a"]
             ];
 
-            verify(code, "ImportNamespaceSpecifier", namesList);
+            await verify(code, "ImportNamespaceSpecifier", namesList);
         });
     });
 
-    describe("markVariableAsUsed()", () => {
+    describe("markVariableAsUsed()", async () => {
 
-        it("should mark variables in current scope as used", () => {
+        it("should mark variables in current scope as used", async () => {
             const code = "var a = 1, b = 2;";
             let spy;
 
@@ -3658,11 +3659,11 @@ describe("SourceCode", () => {
                 }
             });
 
-            linter.verify(code, { rules: { checker: "error" } });
+            await linter.verify(code, { rules: { checker: "error" } });
             assert(spy && spy.calledOnce);
         });
 
-        it("should mark variables in function args as used", () => {
+        it("should mark variables in function args as used", async () => {
             const code = "function abc(a, b) { return 1; }";
             let spy;
 
@@ -3683,11 +3684,11 @@ describe("SourceCode", () => {
                 }
             });
 
-            linter.verify(code, { rules: { checker: "error" } });
+            await linter.verify(code, { rules: { checker: "error" } });
             assert(spy && spy.calledOnce);
         });
 
-        it("should mark variables in higher scopes as used", () => {
+        it("should mark variables in higher scopes as used", async () => {
             const code = "var a, b; function abc() { return 1; }";
             let returnSpy, exitSpy;
 
@@ -3709,12 +3710,12 @@ describe("SourceCode", () => {
                 }
             });
 
-            linter.verify(code, { rules: { checker: "error" } });
+            await linter.verify(code, { rules: { checker: "error" } });
             assert(returnSpy && returnSpy.calledOnce);
             assert(exitSpy && exitSpy.calledOnce);
         });
 
-        it("should mark variables in Node.js environment as used", () => {
+        it("should mark variables in Node.js environment as used", async () => {
             const code = "var a = 1, b = 2;";
             let spy;
 
@@ -3736,11 +3737,11 @@ describe("SourceCode", () => {
                 }
             });
 
-            linter.verify(code, { rules: { checker: "error" }, env: { node: true } });
+            await linter.verify(code, { rules: { checker: "error" }, env: { node: true } });
             assert(spy && spy.calledOnce);
         });
 
-        it("should mark variables in modules as used", () => {
+        it("should mark variables in modules as used", async () => {
             const code = "var a = 1, b = 2;";
             let spy;
 
@@ -3762,11 +3763,11 @@ describe("SourceCode", () => {
                 }
             });
 
-            linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6, sourceType: "module" } }, filename, true);
+            await linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6, sourceType: "module" } }, filename, true);
             assert(spy && spy.calledOnce);
         });
 
-        it("should return false if the given variable is not found", () => {
+        it("should return false if the given variable is not found", async () => {
             const code = "var a = 1, b = 2;";
             let spy;
 
@@ -3782,7 +3783,7 @@ describe("SourceCode", () => {
                 }
             });
 
-            linter.verify(code, { rules: { checker: "error" } });
+            await linter.verify(code, { rules: { checker: "error" } });
             assert(spy && spy.calledOnce);
         });
 

--- a/tests/tools/code-sample-minimizer.js
+++ b/tests/tools/code-sample-minimizer.js
@@ -12,7 +12,7 @@ const reduceBadExampleSize = require("../../tools/code-sample-minimizer");
 //------------------------------------------------------------------------------
 
 describe("reduceBadExampleSize()", () => {
-    it("extracts relevant part of deeply nested code", () => {
+    it("extracts relevant part of deeply nested code", async () => {
         const initialCode = `
             if (true) {
                 while (false) {
@@ -28,7 +28,7 @@ describe("reduceBadExampleSize()", () => {
         const expectedFinalCode = "THIS_EXPRESSION_CAUSES_A_BUG";
 
         assert.strictEqual(
-            reduceBadExampleSize({
+            await reduceBadExampleSize({
                 sourceText: initialCode,
                 predicate: code => code.includes("THIS_EXPRESSION_CAUSES_A_BUG")
             }),
@@ -36,7 +36,7 @@ describe("reduceBadExampleSize()", () => {
         );
     });
 
-    it("removes irrelevant parts of AST nodes with many children", () => {
+    it("removes irrelevant parts of AST nodes with many children", async () => {
         const initialCode = `
             foo;
             bar;
@@ -55,7 +55,7 @@ describe("reduceBadExampleSize()", () => {
         const expectedFinalCode = "THIS_EXPRESSION_CAUSES_A_BUG";
 
         assert.strictEqual(
-            reduceBadExampleSize({
+            await reduceBadExampleSize({
                 sourceText: initialCode,
                 predicate: code => code.includes("THIS_EXPRESSION_CAUSES_A_BUG")
             }),
@@ -63,7 +63,7 @@ describe("reduceBadExampleSize()", () => {
         );
     });
 
-    it("removes irrelevant comments from the source code", () => {
+    it("removes irrelevant comments from the source code", async () => {
         const initialCode = `
         var /* aaa */foo = bar;
     `;
@@ -71,7 +71,7 @@ describe("reduceBadExampleSize()", () => {
         const expectedFinalCode = "var foo = bar;";
 
         assert.strictEqual(
-            reduceBadExampleSize({
+            await reduceBadExampleSize({
                 sourceText: initialCode,
                 predicate: code => code.includes("var") && code.includes("foo = bar")
             }),

--- a/tests/tools/eslint-fuzzer.js
+++ b/tests/tools/eslint-fuzzer.js
@@ -48,7 +48,7 @@ describe("eslint-fuzzer", function() {
 
     describe("when running in crash-only mode", () => {
         describe("when a rule crashes on the given input", () => {
-            it("should report the crash with a minimal config", () => {
+            it("should report the crash with a minimal config", async () => {
                 linter.defineRule("test-fuzzer-rule", {
                     create: context => ({
                         Program() {
@@ -59,7 +59,7 @@ describe("eslint-fuzzer", function() {
                     })
                 });
 
-                const results = fuzz({ count: 1, codeGenerator: () => "foo", checkAutofixes: false, linter });
+                const results = await fuzz({ count: 1, codeGenerator: () => "foo", checkAutofixes: false, linter });
 
                 assert.strictEqual(results.length, 1);
                 assert.strictEqual(results[0].type, "crash");
@@ -70,10 +70,10 @@ describe("eslint-fuzzer", function() {
         });
 
         describe("when no rules crash", () => {
-            it("should return an empty array", () => {
+            it("should return an empty array", async () => {
                 linter.defineRule("test-fuzzer-rule", { create: () => ({}) });
 
-                assert.deepStrictEqual(fuzz({ count: 1, codeGenerator: () => "foo", checkAutofixes: false, linter }), []);
+                assert.deepStrictEqual(await fuzz({ count: 1, codeGenerator: () => "foo", checkAutofixes: false, linter }), []);
             });
         });
     });
@@ -89,7 +89,7 @@ describe("eslint-fuzzer", function() {
         }
 
         describe("when a rule crashes on the given input", () => {
-            it("should report the crash with a minimal config", () => {
+            it("should report the crash with a minimal config", async () => {
                 linter.defineRule("test-fuzzer-rule", {
                     create: context => ({
                         Program() {
@@ -100,7 +100,7 @@ describe("eslint-fuzzer", function() {
                     })
                 });
 
-                const results = fuzz({ count: 1, codeGenerator: () => "foo", checkAutofixes: false, linter });
+                const results = await fuzz({ count: 1, codeGenerator: () => "foo", checkAutofixes: false, linter });
 
                 assert.strictEqual(results.length, 1);
                 assert.strictEqual(results[0].type, "crash");
@@ -110,8 +110,8 @@ describe("eslint-fuzzer", function() {
             });
         });
 
-        describe("when a rule's autofix produces valid syntax", () => {
-            it("does not report any errors", () => {
+        describe("when a rule's autofix produces valid syntax", async () => {
+            it("does not report any errors", async () => {
 
                 // Replaces programs that start with "foo" with "bar"
                 linter.defineRule("test-fuzzer-rule", {
@@ -129,7 +129,7 @@ describe("eslint-fuzzer", function() {
                     })
                 });
 
-                const results = fuzz({
+                const results = await fuzz({
                     count: 1,
 
                     /*
@@ -146,7 +146,7 @@ describe("eslint-fuzzer", function() {
         });
 
         describe("when a rule's autofix produces invalid syntax on the first pass", () => {
-            it("reports an autofix error with a minimal config", () => {
+            it("reports an autofix error with a minimal config", async () => {
 
                 // Replaces programs that start with "foo" with invalid syntax
                 linter.defineRule("test-fuzzer-rule", {
@@ -166,7 +166,7 @@ describe("eslint-fuzzer", function() {
                     })
                 });
 
-                const results = fuzz({
+                const results = await fuzz({
                     count: 1,
                     codeGenerator: () => `foo ${disableFixableRulesComment}`,
                     checkAutofixes: true,
@@ -190,7 +190,7 @@ describe("eslint-fuzzer", function() {
         });
 
         describe("when a rule's autofix produces invalid syntax on the second pass", () => {
-            it("reports an autofix error with a minimal config and the text from the second pass", () => {
+            it("reports an autofix error with a minimal config and the text from the second pass", async () => {
                 const intermediateCode = `bar ${disableFixableRulesComment}`;
 
                 // Replaces programs that start with "foo" with invalid syntax
@@ -216,7 +216,7 @@ describe("eslint-fuzzer", function() {
                     })
                 });
 
-                const results = fuzz({
+                const results = await fuzz({
                     count: 1,
                     codeGenerator: () => `foo ${disableFixableRulesComment}`,
                     checkAutofixes: true,
@@ -240,7 +240,7 @@ describe("eslint-fuzzer", function() {
         });
 
         describe("when a rule crashes on the second autofix pass", () => {
-            it("reports a crash error with a minimal config", () => {
+            it("reports a crash error with a minimal config", async () => {
 
                 // Replaces programs that start with "foo" with invalid syntax
                 linter.defineRule("test-fuzzer-rule", {
@@ -262,7 +262,7 @@ describe("eslint-fuzzer", function() {
                     })
                 });
 
-                const results = fuzz({
+                const results = await fuzz({
                     count: 1,
                     codeGenerator: () => `foo ${disableFixableRulesComment}`,
                     checkAutofixes: true,

--- a/tools/code-sample-minimizer.js
+++ b/tools/code-sample-minimizer.js
@@ -32,13 +32,13 @@ function isStatement(node) {
  * problem is.
  * @param {Object} options Options to process
  * @param {string} options.sourceText Initial piece of "bad" source text
- * @param {function(string): boolean} options.predicate A predicate that returns `true` for bad source text and `false` for good source text
+ * @param {function(string): Promise<boolean>} options.predicate A predicate that returns `true` for bad source text and `false` for good source text
  * @param {Parser} [options.parser] The parser used to parse the source text. Defaults to a modified
  * version of espree that uses recent parser options.
  * @param {Object} [options.visitorKeys] The visitor keys of the AST. Defaults to eslint-visitor-keys.
  * @returns {string} Another piece of "bad" source text, which may or may not be smaller than the original source text.
  */
-function reduceBadExampleSize({
+async function reduceBadExampleSize({
     sourceText,
     predicate,
     parser = {
@@ -73,17 +73,17 @@ function reduceBadExampleSize({
      * @param {string} updatedSourceText The sample
      * @returns {boolean} `true` if the sample is "bad"
      */
-    function reproducesBadCase(updatedSourceText) {
+    async function reproducesBadCase(updatedSourceText) {
         try {
             parser.parse(updatedSourceText);
         } catch {
             return false;
         }
 
-        return predicate(updatedSourceText);
+        return await predicate(updatedSourceText);
     }
 
-    assert(reproducesBadCase(sourceText), "Original source text should reproduce issue");
+    assert(await reproducesBadCase(sourceText), "Original source text should reproduce issue");
     const parseResult = recast.parse(sourceText, { parser });
 
     /**
@@ -93,16 +93,16 @@ function reduceBadExampleSize({
      * resulting AST will still produce "bad" source code.
      * @returns {void}
      */
-    function pruneIrrelevantSubtrees(node) {
+    async function pruneIrrelevantSubtrees(node) {
         for (const key of visitorKeys[node.type]) {
             if (Array.isArray(node[key])) {
                 for (let index = node[key].length - 1; index >= 0; index--) {
                     const [childNode] = node[key].splice(index, 1);
 
-                    if (!reproducesBadCase(recast.print(parseResult).code)) {
+                    if (!(await reproducesBadCase(recast.print(parseResult).code))) {
                         node[key].splice(index, 0, childNode);
                         if (childNode) {
-                            pruneIrrelevantSubtrees(childNode);
+                            await pruneIrrelevantSubtrees(childNode);
                         }
                     }
                 }
@@ -112,15 +112,15 @@ function reduceBadExampleSize({
 
                 if (isMaybeExpression(childNode)) {
                     node[key] = { type: "Identifier", name: generateNewIdentifierName(), range: childNode.range };
-                    if (!reproducesBadCase(recast.print(parseResult).code)) {
+                    if (!await reproducesBadCase(recast.print(parseResult).code)) {
                         node[key] = childNode;
-                        pruneIrrelevantSubtrees(childNode);
+                        await pruneIrrelevantSubtrees(childNode);
                     }
                 } else if (isStatement(childNode)) {
                     node[key] = { type: "EmptyStatement", range: childNode.range };
-                    if (!reproducesBadCase(recast.print(parseResult).code)) {
+                    if (!await reproducesBadCase(recast.print(parseResult).code)) {
                         node[key] = childNode;
-                        pruneIrrelevantSubtrees(childNode);
+                        await pruneIrrelevantSubtrees(childNode);
                     }
                 }
             }
@@ -132,7 +132,7 @@ function reduceBadExampleSize({
      * @param {ASTNode} node A node which produces "bad" source code
      * @returns {ASTNode} A descendent of `node` which is also bad
      */
-    function extractRelevantChild(node) {
+    async function extractRelevantChild(node) {
         const childNodes = visitorKeys[node.type]
             .flatMap(key => (Array.isArray(node[key]) ? node[key] : [node[key]]));
 
@@ -142,18 +142,18 @@ function reduceBadExampleSize({
             }
 
             if (isMaybeExpression(childNode)) {
-                if (reproducesBadCase(recast.print(childNode).code)) {
-                    return extractRelevantChild(childNode);
+                if (await reproducesBadCase(recast.print(childNode).code)) {
+                    return await extractRelevantChild(childNode);
                 }
 
             } else if (isStatement(childNode)) {
-                if (reproducesBadCase(recast.print(childNode).code)) {
-                    return extractRelevantChild(childNode);
+                if (await reproducesBadCase(recast.print(childNode).code)) {
+                    return await extractRelevantChild(childNode);
                 }
             } else {
-                const childResult = extractRelevantChild(childNode);
+                const childResult = await extractRelevantChild(childNode);
 
-                if (reproducesBadCase(recast.print(childResult).code)) {
+                if (await reproducesBadCase(recast.print(childResult).code)) {
                     return childResult;
                 }
             }
@@ -166,7 +166,7 @@ function reduceBadExampleSize({
      * @param {string} text A piece of "bad" source text
      * @returns {string} A piece of "bad" source text with fewer and/or simpler comments.
      */
-    function removeIrrelevantComments(text) {
+    async function removeIrrelevantComments(text) {
         const ast = parser.parse(text);
 
         if (ast.comments) {
@@ -182,8 +182,8 @@ function reduceBadExampleSize({
                     // Try deleting the contents of the comment
                     text.slice(0, comment.range[0] + 2) + text.slice(comment.type === "Block" ? comment.range[1] - 2 : comment.range[1])
                 ]) {
-                    if (reproducesBadCase(potentialSimplification)) {
-                        return removeIrrelevantComments(potentialSimplification);
+                    if (await reproducesBadCase(potentialSimplification)) {
+                        return await removeIrrelevantComments(potentialSimplification);
                     }
                 }
             }
@@ -192,13 +192,13 @@ function reduceBadExampleSize({
         return text;
     }
 
-    pruneIrrelevantSubtrees(parseResult.program);
-    const relevantChild = recast.print(extractRelevantChild(parseResult.program)).code;
+    await pruneIrrelevantSubtrees(parseResult.program);
+    const relevantChild = recast.print(await extractRelevantChild(parseResult.program)).code;
 
-    assert(reproducesBadCase(relevantChild), "Extracted relevant source text should reproduce issue");
-    const result = removeIrrelevantComments(relevantChild);
+    assert(await reproducesBadCase(relevantChild), "Extracted relevant source text should reproduce issue");
+    const result = await removeIrrelevantComments(relevantChild);
 
-    assert(reproducesBadCase(result), "Source text with irrelevant comments removed should reproduce issue");
+    assert(await reproducesBadCase(result), "Source text with irrelevant comments removed should reproduce issue");
     return result;
 }
 


### PR DESCRIPTION
I stumbled across https://github.com/eslint/eslint/issues/15394 and thought it would be interesting to see what the code would look like and which API points would need to change. Roughly every developer-facing API that runs any rule logic needs to become async:

* `CLIEngine`'s `executeOnFiles` and `executeOnText`
* `Linter`'s `verify` and `verifyAndFix`
* `RuleTester`'s `run`
* The `Flat*` equivalents for all of ☝️ 

This branch gets all but tests passing with ` ./node_modules/mocha/bin/_mocha  -R progress -t 1000 -c "tests/{bin,conf,lib,tools}/**/*.js" --reporter list`. It doesn't update any docs.

